### PR TITLE
Update service delivery card to be more specific

### DIFF
--- a/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
@@ -1583,7 +1583,7 @@ exports[`ActivityFeedCard when there is a service delivery should render service
         <span
           className="sc-eHgmQL duXTff"
         >
-          View interaction details
+          View service delivery details
         </span>
       </summary>
       <div
@@ -1697,7 +1697,7 @@ exports[`ActivityFeedCard when there is a service delivery should render service
           href="https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/854d8d31-7405-4625-a957-0ed2c3092caa"
           muted={false}
         >
-          Go to the interaction detail page
+          Go to the service delivery detail page
         </a>
       </div>
     </details>

--- a/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
@@ -1712,7 +1712,7 @@ exports[`ActivityFeedCard when there is a service delivery should render service
       <span
         className="sc-iujRgT hrmgYI"
       >
-        Completed interaction
+        Completed service delivery
       </span>
     </div>
   </div>

--- a/src/activity-feed/activity-feed-cards/Interaction.jsx
+++ b/src/activity-feed/activity-feed-cards/Interaction.jsx
@@ -30,7 +30,8 @@ export default class Interaction extends React.Component {
       <Card isUpcoming={transformed.isUpcoming}>
         <CardContent>
           <CardHeading link={{ url: transformed.url, text: transformed.subject }}></CardHeading>
-          <CardDetails summary="View interaction details" link={{ url: transformed.url, text: 'Go to the interaction detail page' }}>
+          <CardDetails summary={`View ${transformed.typeText} details`}
+                       link={{ url: transformed.url, text: `Go to the ${transformed.typeText} detail page` }}>
             <CardTable rows={
               [
                 { header: 'Contact(s)', content: CardUtils.getPeopleAsList(activity, 'Contact') },

--- a/src/activity-feed/activity-feed-cards/InteractionUtils.js
+++ b/src/activity-feed/activity-feed-cards/InteractionUtils.js
@@ -43,10 +43,12 @@ export default class CardUtils {
     const status = getStatus(activity)
     const badge = isServiceDelivery(activity) ? BADGE_LABELS.COMPLETED_SERVICE_DELIVERY : BADGE_LABELS[status.toUpperCase()]
     const isUpcoming = status === STATUS.UPCOMING
+    const typeText = isServiceDelivery(activity) ? 'service delivery' : 'interaction'
 
     return {
       badge,
       isUpcoming,
+      typeText,
     }
   }
 }

--- a/src/activity-feed/activity-feed-cards/InteractionUtils.js
+++ b/src/activity-feed/activity-feed-cards/InteractionUtils.js
@@ -1,4 +1,4 @@
-import { get } from 'lodash'
+import { get, includes } from 'lodash'
 
 const STATUS = {
   DRAFT: 'draft',
@@ -14,7 +14,7 @@ const BADGE_LABELS = {
   UPCOMING: 'Upcoming interaction',
   INCOMPLETE: 'Incomplete interaction',
   CANCELLED: 'Cancelled interaction',
-  UNKNOWN: 'Unknown status',
+  COMPLETED_SERVICE_DELIVERY: 'Completed service delivery',
 }
 
 const getStatus = (activity) => {
@@ -33,10 +33,15 @@ const getStatus = (activity) => {
   }
 }
 
+const isServiceDelivery = (activity) => {
+  const activityTypes = get(activity, 'object.type')
+  return includes(activityTypes, 'dit:ServiceDelivery')
+}
+
 export default class CardUtils {
   static transform(activity) {
     const status = getStatus(activity)
-    const badge = BADGE_LABELS[status.toUpperCase()]
+    const badge = isServiceDelivery(activity) ? BADGE_LABELS.COMPLETED_SERVICE_DELIVERY : BADGE_LABELS[status.toUpperCase()]
     const isUpcoming = status === STATUS.UPCOMING
 
     return {

--- a/src/activity-feed/activity-feed-cards/InteractionUtils.test.js
+++ b/src/activity-feed/activity-feed-cards/InteractionUtils.test.js
@@ -8,6 +8,7 @@ describe('InteractionUtils.js', () => {
       test('should set the badge as "Cancelled interaction"', () => {
         const actual = InteractionUtils.transform({
           object: {
+            type: 'dit:Interaction',
             'dit:status': 'draft',
             'dit:archived': true,
           }
@@ -16,6 +17,7 @@ describe('InteractionUtils.js', () => {
         expect(actual).toEqual({
           badge: 'Cancelled interaction',
           isUpcoming: false,
+          typeText: 'interaction',
         })
       })
     })
@@ -24,6 +26,7 @@ describe('InteractionUtils.js', () => {
       test('should set the badge as "Upcoming interaction"', () => {
         const actual = InteractionUtils.transform({
           object: {
+            type: 'dit:Interaction',
             'dit:status': 'draft',
             'startTime': moment().add(1, 'days').toISOString(),
           }
@@ -32,6 +35,7 @@ describe('InteractionUtils.js', () => {
         expect(actual).toEqual({
           badge: 'Upcoming interaction',
           isUpcoming: true,
+          typeText: 'interaction',
         })
       })
     })
@@ -40,6 +44,7 @@ describe('InteractionUtils.js', () => {
       test('should set the badge as "Upcoming interaction"', () => {
         const actual = InteractionUtils.transform({
           object: {
+            type: 'dit:Interaction',
             'dit:status': 'draft',
             'startTime': moment().subtract(1, 'days').toISOString(),
           }
@@ -48,6 +53,7 @@ describe('InteractionUtils.js', () => {
         expect(actual).toEqual({
           badge: 'Incomplete interaction',
           isUpcoming: false,
+          typeText: 'interaction',
         })
       })
     })
@@ -56,6 +62,7 @@ describe('InteractionUtils.js', () => {
       test('should set the badge as "Completed interaction"', () => {
         const actual = InteractionUtils.transform({
           object: {
+            type: 'dit:Interaction',
             'dit:status': 'complete',
           }
         })
@@ -63,6 +70,24 @@ describe('InteractionUtils.js', () => {
         expect(actual).toEqual({
           badge: 'Completed interaction',
           isUpcoming: false,
+          typeText: 'interaction',
+        })
+      })
+    })
+
+    describe('when the service delivery is complete', () => {
+      test('should set the badge as "Completed service delivery"', () => {
+        const actual = InteractionUtils.transform({
+          object: {
+            type: 'dit:ServiceDelivery',
+            'dit:status': 'complete',
+          }
+        })
+
+        expect(actual).toEqual({
+          badge: 'Completed service delivery',
+          isUpcoming: false,
+          typeText: 'service delivery',
         })
       })
     })


### PR DESCRIPTION
## Change
Currently service deliveries are using "Completed interaction" but they should be using "Completed
service delivery"

Link text with `interaction` should use `service delivery` for service deliveries.

## Before
<img width="969" alt="Screenshot 2019-06-21 at 13 25 33" src="https://user-images.githubusercontent.com/1150417/59922291-61af6c80-9428-11e9-9a6d-daa5e3962540.png">

## After
<img width="976" alt="Screenshot 2019-06-21 at 13 25 16" src="https://user-images.githubusercontent.com/1150417/59922312-6e33c500-9428-11e9-9db2-a017756dac4a.png">