### PR TITLE
Display "1 activity" instead of "1 activities" in the activity feed header

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "govuk-react": "^0.7.0",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
+    "pluralise": "^1.0.1",
     "prop-types": "^15.7.2",
     "react-markdown": "^4.0.8",
     "styled-components": "^4.2.0"

--- a/src/activity-feed/ActivityFeedHeader.jsx
+++ b/src/activity-feed/ActivityFeedHeader.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types'
 import { H2, Button } from 'govuk-react'
 import styled from 'styled-components'
 import { SPACING } from '@govuk-react/constants'
+import pluralise from 'pluralise'
 
 const HeaderSummary = styled.div`
   display: flex;
@@ -46,7 +47,7 @@ export default class ActivityFeedHeader extends React.Component {
 
   render() {
     const { totalActivities, addContentText, addContentLink } = this.props
-    const headerText = totalActivities > 0 ? `${totalActivities} activities` : 'Activities'
+    const headerText = pluralise.withCount(totalActivities, '% activity', '% activities', 'Activities')
     const showAddContentButton = addContentText && addContentLink
 
     return (

--- a/src/activity-feed/ActivityFeedHeader.test.jsx
+++ b/src/activity-feed/ActivityFeedHeader.test.jsx
@@ -23,6 +23,17 @@ describe('ActivityFeedHeader', () => {
       .toJSON()
     expect(tree).toMatchSnapshot()
   })
+
+  test('renders header with one activity', () => {
+    const tree = renderer
+      .create(
+        <ActivityFeedHeader
+          totalActivities={1}
+        />
+      )
+      .toJSON()
+    expect(tree).toMatchSnapshot()
+  })
 })
 
 

--- a/src/activity-feed/__snapshots__/ActivityFeed.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeed.test.jsx.snap
@@ -71,7 +71,7 @@ exports[`ActivityFeed renders single activity 1`] = `
         className="sc-cMljjf leOqMw"
         size="LARGE"
       >
-        1 activities
+        1 activity
       </h2>
     </div>
     <div

--- a/src/activity-feed/__snapshots__/ActivityFeedHeader.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeedHeader.test.jsx.snap
@@ -28,6 +28,26 @@ exports[`ActivityFeedHeader renders header with all props defined 1`] = `
 </div>
 `;
 
+exports[`ActivityFeedHeader renders header with one activity 1`] = `
+<div
+  className="sc-cmthru jNIEHA"
+>
+  <div
+    className="sc-hMFtBS kVBfdo"
+  >
+    <h2
+      className="sc-cMljjf leOqMw"
+      size="LARGE"
+    >
+      1 activity
+    </h2>
+  </div>
+  <div
+    className="sc-cLQEGU oWkRe"
+  />
+</div>
+`;
+
 exports[`ActivityFeedHeader renders header without props 1`] = `
 <div
   className="sc-cmthru jNIEHA"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7320,6 +7320,11 @@ pkg-up@2.0.0:
   dependencies:
     find-up "^2.1.0"
 
+pluralise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/pluralise/-/pluralise-1.0.1.tgz#c17a240ca8c6febb1439f7d2e78077defd128500"
+  integrity sha512-C2ddX33ihY6e3S7JYG8FspCf0o08D8tsXef2zcEx9geuX3vlOhkmUy6pXjRvmlVC60p7J5l3OxviKMFWLMs/0g==
+
 pn@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/pn/-/pn-1.1.0.tgz#e2f4cef0e219f463c179ab37463e4e1ecdccbafb"


### PR DESCRIPTION
https://trello.com/c/ZVZurdkL/1327-display-1-activity-instead-of-1-activities-in-the-activity-feed