### PR TITLE
Update interaction and service delivery completed badge text

### DIFF
--- a/fixtures/activity_feed/interactions/service_delivery.json
+++ b/fixtures/activity_feed/interactions/service_delivery.json
@@ -19,7 +19,7 @@
 
     "dit:status": "complete",
     "dit:archived": false,
-    "dit:subject": "Openening of overseas office",
+    "dit:subject": "Opening of overseas office",
     "dit:service": {
       "name": "Events - Overseas"
     },

--- a/src/activity-feed/__snapshots__/ActivityFeed.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeed.test.jsx.snap
@@ -114,7 +114,7 @@ exports[`ActivityFeed renders single activity 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -310,7 +310,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -478,7 +478,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -646,7 +646,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -814,7 +814,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -982,7 +982,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -1150,7 +1150,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -1318,7 +1318,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -1486,7 +1486,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -1654,7 +1654,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -1822,7 +1822,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -1990,7 +1990,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -2158,7 +2158,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -2326,7 +2326,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -2494,7 +2494,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -2662,7 +2662,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -2830,7 +2830,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -2998,7 +2998,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -3166,7 +3166,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -3334,7 +3334,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>
@@ -3502,7 +3502,7 @@ exports[`ActivityFeed renders with "Load more" link 1`] = `
               <span
                 className="sc-GMQeP gJuUpj"
               >
-                Completed interaction
+                Interaction
               </span>
             </div>
           </div>

--- a/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
@@ -827,7 +827,7 @@ exports[`ActivityFeedCard when the interaction does not have a service should re
         <span
           className="sc-GMQeP gJuUpj"
         >
-          Completed interaction
+          Interaction
         </span>
       </div>
     </div>
@@ -1454,7 +1454,7 @@ exports[`ActivityFeedCard when the interaction is complete should render interac
         <span
           className="sc-GMQeP gJuUpj"
         >
-          Completed interaction
+          Interaction
         </span>
       </div>
     </div>
@@ -1623,7 +1623,7 @@ exports[`ActivityFeedCard when there is a service delivery should render service
         <span
           className="sc-GMQeP gJuUpj"
         >
-          Completed service delivery
+          Service delivery
         </span>
       </div>
     </div>
@@ -1794,7 +1794,7 @@ exports[`ActivityFeedCard when there is an interaction should render interaction
         <span
           className="sc-GMQeP gJuUpj"
         >
-          Completed interaction
+          Interaction
         </span>
       </div>
     </div>
@@ -1963,7 +1963,7 @@ exports[`ActivityFeedCard when there is an interaction without any people involv
         <span
           className="sc-GMQeP gJuUpj"
         >
-          Completed interaction
+          Interaction
         </span>
       </div>
     </div>

--- a/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
@@ -1609,7 +1609,7 @@ exports[`ActivityFeedCard when there is a service delivery should render service
           href="https://example.com/companies/a4ead59f-dfc8-e511-a5e6-e4115bead28a/interactions/854d8d31-7405-4625-a957-0ed2c3092caa"
           muted={false}
         >
-          Openening of overseas office
+          Opening of overseas office
         </a>
       </h3>
     </div>

--- a/src/activity-feed/activity-feed-cards/InteractionUtils.js
+++ b/src/activity-feed/activity-feed-cards/InteractionUtils.js
@@ -7,12 +7,11 @@ const STATUS = {
   UPCOMING: 'upcoming',
   INCOMPLETE: 'incomplete',
   CANCELLED: 'cancelled',
-  UNKNOWN: 'unknown',
 }
 
 const BADGES = {
   COMPLETE: {
-    text: 'Completed interaction',
+    text: 'Interaction',
     borderColour: GREEN,
   },
   UPCOMING: {
@@ -27,8 +26,8 @@ const BADGES = {
     text: 'Cancelled interaction',
     borderColour: RED,
   },
-  COMPLETED_SERVICE_DELIVERY: {
-    text: 'Completed service delivery',
+  SERVICE_DELIVERY: {
+    text: 'Service delivery',
     borderColour: GREEN,
   },
 }
@@ -59,7 +58,7 @@ export default class CardUtils {
     const status = getStatus(activity)
 
     const badge = isServiceDelivery(activity)
-      ? BADGES.COMPLETED_SERVICE_DELIVERY
+      ? BADGES.SERVICE_DELIVERY
       : BADGES[status.toUpperCase()]
 
     const isUpcoming = status === STATUS.UPCOMING

--- a/src/activity-feed/activity-feed-cards/InteractionUtils.test.js
+++ b/src/activity-feed/activity-feed-cards/InteractionUtils.test.js
@@ -81,7 +81,7 @@ describe('InteractionUtils.js', () => {
           typeText: 'interaction',
           isUpcoming: false,
           badge: {
-            text: 'Completed interaction',
+            text: 'Interaction',
             borderColour: GREEN,
           },
         })
@@ -101,7 +101,7 @@ describe('InteractionUtils.js', () => {
           typeText: 'service delivery',
           isUpcoming: false,
           badge: {
-            text: 'Completed service delivery',
+            text: 'Service delivery',
             borderColour: GREEN,
           },
         })


### PR DESCRIPTION
## Change
Updates badge text for completed interactions and service deliveries to be simply `Interaction` and `Service delivery`.

## Before
<img width="967" alt="Screenshot 2019-06-25 at 11 09 58" src="https://user-images.githubusercontent.com/1150417/60090403-63d03e80-973a-11e9-9cb0-542948916f75.png">

## After
<img width="958" alt="Screenshot 2019-06-25 at 11 11 36" src="https://user-images.githubusercontent.com/1150417/60090414-6af74c80-973a-11e9-93f9-d842fddd6eff.png">