### PR TITLE
ci: Add debug option to semantic-release

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "storybook:build": "rimraf storybook-static && build-storybook",
     "storybook:release": "yarn storybook:build && git-directory-deploy --directory storybook-static --branch gh-pages",
     "prepack": "yarn build",
-    "release": "semantic-release",
+    "release": "semantic-release --debug",
     "postpublish": "[ \"${npm_config_tag:-latest}\" != latest ] || yarn storybook:release"
   },
   "pre-commit": "lint",


### PR DESCRIPTION
Add `--debug` option to the `semantic-release` command so we have a better understanding what's going on.