### PR TITLE
ci: Hide output of the build-storybook command

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "eslint './src/**/*.{js,jsx}'",
     "lint:fix": "yarn lint --fix",
     "storybook": "start-storybook",
-    "storybook:build": "rimraf storybook-static && build-storybook",
+    "storybook:build": "rimraf storybook-static && build-storybook --quiet",
     "storybook:release": "yarn storybook:build && git-directory-deploy --directory storybook-static --branch gh-pages",
     "prepack": "yarn build",
     "release": "semantic-release --debug",


### PR DESCRIPTION
Add `--quiet` argument to the `build-storybook` so the console output in CircleCI is still readable.

Example build with unreadable output: https://circleci.com/gh/uktrade/data-hub-components/601