### PR TITLE
feat: Add entity search cannot find footer

### DIFF
--- a/src/entity-search/CannotFindDetails.jsx
+++ b/src/entity-search/CannotFindDetails.jsx
@@ -1,0 +1,40 @@
+import { Details, Link, Paragraph } from 'govuk-react'
+import React from 'react'
+import PropTypes from 'prop-types'
+import { uniqueId } from 'lodash'
+
+const CannotFindDetails = ({ summary, actions, link }) => {
+  const onLinkClick = (e) => {
+    e.preventDefault()
+    link.onClick()
+  }
+
+  return (
+    <Details summary={summary}>
+      <div>
+        <Paragraph>Try refining your search by taking the following actions:</Paragraph>
+        <ul>
+          {actions.map(text => <li key={uniqueId()}>{text}</li>)}
+        </ul>
+        <Link
+          href={link.url ? link.url : '#'}
+          onClick={link.onClick ? onLinkClick : null}
+        >
+          {link.text}
+        </Link>
+      </div>
+    </Details>
+  )
+}
+
+CannotFindDetails.propTypes = {
+  summary: PropTypes.string.isRequired,
+  actions: PropTypes.arrayOf(PropTypes.string).isRequired,
+  link: PropTypes.shape({
+    text: PropTypes.string.isRequired,
+    url: PropTypes.string,
+    onClick: PropTypes.func,
+  }).isRequired,
+}
+
+export default CannotFindDetails

--- a/src/entity-search/EntitySearch.jsx
+++ b/src/entity-search/EntitySearch.jsx
@@ -4,6 +4,7 @@ import { Button } from 'govuk-react'
 import styled from 'styled-components'
 import { SPACING } from '@govuk-react/constants'
 
+import CannotFindDetails from './CannotFindDetails'
 import EntityList from './EntityList'
 import EntityFilters from './EntityFilters'
 import useFilter from './useFilter'
@@ -13,15 +14,17 @@ const StyledButton = styled(Button)`
 `
 StyledButton.displayName = 'Search'
 
-const EntitySearch = ({ onEntitySearch, entities, entityFilters }) => {
+const EntitySearch = ({ onEntitySearch, entities, entityFilters, cannotFind }) => {
   const { filters, setFilter } = useFilter()
-
   return (
     <>
       <EntityFilters entityFilters={entityFilters} setFilter={setFilter} />
 
       {entities && entities.length ? (
-        <EntityList entities={entities} />
+        <>
+          <EntityList entities={entities} />
+          <CannotFindDetails {...cannotFind} />
+        </>
       ) : null}
 
       <StyledButton onClick={() => onEntitySearch(filters)}>Search</StyledButton>
@@ -36,6 +39,15 @@ EntitySearch.propTypes = {
   })).isRequired,
   onEntitySearch: PropTypes.func.isRequired,
   entityFilters: PropTypes.array.isRequired,
+  cannotFind: PropTypes.shape({
+    summary: PropTypes.string.isRequired,
+    actions: PropTypes.arrayOf(PropTypes.string).isRequired,
+    link: PropTypes.shape({
+      text: PropTypes.string.isRequired,
+      url: PropTypes.string,
+      onClick: PropTypes.func,
+    }).isRequired,
+  }).isRequired,
 }
 
 export default EntitySearch

--- a/src/entity-search/EntitySearch.stories.jsx
+++ b/src/entity-search/EntitySearch.stories.jsx
@@ -4,20 +4,61 @@ import { GridCol, GridRow, Main, H2 } from 'govuk-react'
 import { SPACING } from '@govuk-react/constants'
 import axios from 'axios'
 import MockAdapter from 'axios-mock-adapter'
+import PropTypes from 'prop-types'
 
 import dataHubAddCompany from '../../assets/images/data-hub-add-company.png'
 import companySearchFixture from './fixtures/company-search'
 import dnbCompanySearchDataProvider from './data-providers/DnbCompanySearch'
 import EntitySearchWithDataProvider from './EntitySearchWithDataProvider'
 
+const mock = new MockAdapter(axios)
+const apiEndpoint = 'http://localhost:3010/v4/dnb/company-search'
+const apiEndpointWithParameters = new RegExp(`${apiEndpoint}.+`)
+mock.onPost(apiEndpoint).reply(200, companySearchFixture)
+mock.onPost(apiEndpointWithParameters).reply(200, companySearchFixture)
+
+const EntitySearchForStorybook = ({ cannotFindLink }) => {
+  return (
+    <EntitySearchWithDataProvider
+      getEntities={dnbCompanySearchDataProvider(apiEndpoint)}
+      entityFilters={[
+        [
+          { label: 'Company name', key: 'search_term' },
+        ],
+        [
+          { label: 'Company postcode', key: 'address_postcode', width: 'one-half' },
+        ],
+      ]}
+      cannotFind={{
+        summary: 'I cannot find the company I am looking for',
+        actions: [
+          'Check the country selected is correct',
+          'Check for spelling errors in the company name',
+          'Remove or add Ltd or Limited to your search',
+        ],
+        link: cannotFindLink,
+      }}
+    />
+  )
+}
+
+EntitySearchForStorybook.propTypes = {
+  cannotFindLink: {
+    text: PropTypes.string.isRequired,
+    url: PropTypes.string,
+    onClick: PropTypes.func,
+  },
+}
+
+EntitySearchForStorybook.defaultProps = {
+  cannotFindLink: {
+    text: 'I still cannot find the company',
+    url: 'http://stillcannotfind.com',
+  },
+}
+
 storiesOf('EntitySearch', module)
   .add('Data Hub company search', () => {
-    const mock = new MockAdapter(axios)
-    const apiEndpoint = 'http://localhost:3010/v4/dnb/company-search'
-    const apiEndpointWithParameters = new RegExp(`${apiEndpoint}.+`)
-    mock.onPost(apiEndpoint).reply(200, companySearchFixture)
-    mock.onPost(apiEndpointWithParameters).reply(200, companySearchFixture)
-
     return (
       <Main>
         <GridRow>
@@ -28,16 +69,30 @@ storiesOf('EntitySearch', module)
         <GridRow>
           <GridCol style={{ margin: SPACING.SCALE_2 }}>
             <H2 style={{ fontSize: '24px' }}>Find the company</H2>
-            <EntitySearchWithDataProvider
-              getEntities={dnbCompanySearchDataProvider(apiEndpoint)}
-              entityFilters={[
-                [
-                  { label: 'Company name', key: 'search_term' },
-                ],
-                [
-                  { label: 'Company postcode', key: 'address_postcode', width: 'one-half' },
-                ],
-              ]}
+            <EntitySearchForStorybook />
+          </GridCol>
+        </GridRow>
+      </Main>
+    )
+  })
+  .add('Data Hub company search with cannot find link callback', () => {
+    return (
+      <Main>
+        <GridRow>
+          <GridCol>
+            <img src={dataHubAddCompany} width="960" alt="Data Hub" />
+          </GridCol>
+        </GridRow>
+        <GridRow>
+          <GridCol style={{ margin: SPACING.SCALE_2 }}>
+            <H2 style={{ fontSize: '24px' }}>Find the company</H2>
+            <EntitySearchForStorybook
+              cannotFindLink={{
+                text: 'I still cannot find the company',
+                onClick: () => {
+                  alert('Still cannot find :(')
+                },
+              }}
             />
           </GridCol>
         </GridRow>

--- a/src/entity-search/EntitySearch.test.jsx
+++ b/src/entity-search/EntitySearch.test.jsx
@@ -1,5 +1,4 @@
 import React from 'react'
-import renderer from 'react-test-renderer'
 import { mount } from 'enzyme'
 import MockAdapter from 'axios-mock-adapter'
 import axios from 'axios'
@@ -23,106 +22,137 @@ mock
   .onPost(`${API_ENDPOINT}?address_postcode=BN1%204SE`)
   .reply(200, companySearchFilteredByPostcode)
 
-function flushPromises() {
+const flushPromises = () => {
   return new Promise((resolve) => {
     setTimeout(resolve, 0)
   })
 }
 
+const wrapEntitySearch = (cannotFindLink = {
+  url: 'http://stillcannotfind.com',
+  text: 'still cannot find',
+}) => {
+  return mount(<EntitySearchWithDataProvider
+    getEntities={getEntities(API_ENDPOINT)}
+    entityFilters={[
+      [
+        { label: 'Company name', key: 'search_term' },
+      ],
+      [
+        { label: 'Company postcode', key: 'address_postcode', width: 'one-half' },
+      ],
+    ]}
+    cannotFind={{
+      summary: 'cannot find summary',
+      actions: [
+        'action 1',
+        'action 2',
+      ],
+      link: cannotFindLink,
+    }}
+  />)
+}
+
 describe('EntitySearch', () => {
   describe('when initially loading the entity search component', () => {
     test('should render the component without entities', () => {
-      const tree = renderer
-        .create(<EntitySearchWithDataProvider
-          getEntities={getEntities(API_ENDPOINT)}
-          entityFilters={[
-            [
-              { label: 'Company name', key: 'search_term' },
-            ],
-          ]}
-        />)
-        .toJSON()
-      expect(tree).toMatchSnapshot()
+      const wrappedEntitySearch = wrapEntitySearch()
+      expect(wrappedEntitySearch.debug()).toMatchSnapshot()
     })
   })
 
   describe('when the "Search" button has been clicked', () => {
     test('should render the component with entities', async () => {
-      const wrapper = mount(<EntitySearchWithDataProvider
-        getEntities={getEntities(API_ENDPOINT)}
-        entityFilters={[
-          [
-            { label: 'Company name', key: 'search_term' },
-          ],
-        ]}
-      />)
+      const wrappedEntitySearch = wrapEntitySearch()
 
-      wrapper.find('Search').simulate('click')
+      wrappedEntitySearch.find('Search').simulate('click')
 
       await act(flushPromises)
 
-      wrapper.update()
+      wrappedEntitySearch.update()
 
-      expect(wrapper.debug()).toMatchSnapshot()
+      expect(wrappedEntitySearch.debug()).toMatchSnapshot()
     })
   })
 
   describe('when the company name filter is applied', () => {
     test('should render the component with filtered entities', async () => {
-      const wrapper = mount(<EntitySearchWithDataProvider
-        getEntities={getEntities(API_ENDPOINT)}
-        entityFilters={[
-          [
-            { label: 'Company name', key: 'search_term' },
-          ],
-        ]}
-      />)
+      const wrappedEntitySearch = wrapEntitySearch()
 
-      wrapper
+      wrappedEntitySearch
         .find('[name="search_term"]')
         .at(1)
         .simulate('change', { target: { value: 'some other company' } })
 
-      wrapper
+      wrappedEntitySearch
         .find('Search')
         .simulate('click')
 
       await act(flushPromises)
 
-      wrapper.update()
+      wrappedEntitySearch.update()
 
-      expect(wrapper.debug()).toMatchSnapshot()
+      expect(wrappedEntitySearch.debug()).toMatchSnapshot()
     })
   })
 
   describe('when the company postcode filter is applied', () => {
     test('should render the component with filtered entities', async () => {
-      const wrapper = mount(<EntitySearchWithDataProvider
-        getEntities={getEntities(API_ENDPOINT)}
-        entityFilters={[
-          [
-            { label: 'Company name', key: 'search_term' },
-          ],
-          [
-            { label: 'Company postcode', key: 'address_postcode', width: 'one-half' },
-          ],
-        ]}
-      />)
+      const wrappedEntitySearch = wrapEntitySearch()
 
-      wrapper
+      wrappedEntitySearch
         .find('[name="address_postcode"]')
         .at(1)
         .simulate('change', { target: { value: 'BN1 4SE' } })
 
-      wrapper
+      wrappedEntitySearch
         .find('Search')
         .simulate('click')
 
       await act(flushPromises)
 
-      wrapper.update()
+      wrappedEntitySearch.update()
 
-      expect(wrapper.debug()).toMatchSnapshot()
+      expect(wrappedEntitySearch.debug()).toMatchSnapshot()
+    })
+  })
+
+  describe('when the the cannot find link has a callback', () => {
+    let wrappedEntitySearch
+    let onCannotFindLinkClick
+    let preventDefaultMock
+
+    beforeAll(async () => {
+      onCannotFindLinkClick = jest.fn()
+      preventDefaultMock = jest.fn()
+
+      wrappedEntitySearch = wrapEntitySearch({
+        text: 'still cannot find',
+        onClick: onCannotFindLinkClick,
+      })
+
+      wrappedEntitySearch.find('Search').simulate('click')
+
+      await act(flushPromises)
+
+      wrappedEntitySearch.update()
+
+      wrappedEntitySearch
+        .find('[href="#"]')
+        .at(1)
+        .simulate('click', { preventDefault: preventDefaultMock })
+    })
+
+    test('should render the component', async () => {
+      expect(wrappedEntitySearch.debug()).toMatchSnapshot()
+    })
+
+    test('should prevent the default link action', async () => {
+      expect(preventDefaultMock.mock.calls.length).toEqual(1)
+    })
+
+    test('should call the onCannotFindLinkClick event', async () => {
+      expect(onCannotFindLinkClick.mock.calls.length).toEqual(1)
     })
   })
 })

--- a/src/entity-search/__snapshots__/EntitySearch.test.jsx.snap
+++ b/src/entity-search/__snapshots__/EntitySearch.test.jsx.snap
@@ -1,47 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`EntitySearch when initially loading the entity search component should render the component without entities 1`] = `
-Array [
-  <div
-    className="sc-bAeIUo fWSbPZ"
-  >
-    <div
-      className="sc-bMVAic AOkMI sc-hzDkRC hNOsPM"
-    >
-      <div
-        className="sc-bRBYWo cfvpGy"
-      >
-        <label
-          className="sc-ckVGcZ jNBPWj"
-          onChange={[Function]}
-        >
-          <span
-            className="sc-kGXeez fmtdbL"
-          >
-            Company name
-          </span>
-          <input
-            className="sc-dxgOiQ KJcFQ"
-            name="search_term"
-            type="text"
-          />
-        </label>
-      </div>
-    </div>
-  </div>,
-  <button
-    className="sc-iujRgT bnRApC sc-VigVT krXvSZ"
-    disabled={false}
-    onClick={[Function]}
-  >
-    Search
-  </button>,
-]
-`;
-
-exports[`EntitySearch when the "Search" button has been clicked should render the component with entities 1`] = `
-"<EntitySearchWithDataProvider getEntities={[Function]} entityFilters={{...}}>
-  <EntitySearch entities={{...}} onEntitySearch={[Function: onEntitySearch]} getEntities={[Function]} entityFilters={{...}}>
+"<EntitySearchWithDataProvider getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
+  <EntitySearch entities={{...}} onEntitySearch={[Function: onEntitySearch]} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
@@ -76,6 +37,184 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
                                                 <styled.input type=\\"text\\" error={[undefined]} name=\\"search_term\\">
                                                   <StyledComponent type=\\"text\\" error={[undefined]} name=\\"search_term\\" forwardedComponent={{...}} forwardedRef={{...}}>
                                                     <input type=\\"text\\" name=\\"search_term\\" className=\\"sc-dxgOiQ KJcFQ\\" />
+                                                  </StyledComponent>
+                                                </styled.input>
+                                              </Input>
+                                            </label>
+                                          </StyledComponent>
+                                        </styled.label>
+                                      </Label>
+                                    </InputField>
+                                  </EntityFilter>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </GridCol>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </GridRow>
+                </StyledComponent>
+              </Styled(GridRow)>
+            </EntityFilterRow>
+            <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
+              <Styled(GridRow)>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <GridRow className=\\"sc-bMVAic AOkMI\\">
+                    <styled.div className=\\"sc-bMVAic AOkMI\\">
+                      <StyledComponent className=\\"sc-bMVAic AOkMI\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-bMVAic AOkMI sc-hzDkRC hNOsPM\\">
+                          <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                            <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                              <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-bRBYWo cROHUG\\">
+                                  <EntityFilter filter={{...}} setFilter={[Function: setFilter]}>
+                                    <InputField onChange={[Function: onChange]} input={{...}} hint={[undefined]} meta={{...}}>
+                                      <Label onChange={[Function: onChange]} error={false}>
+                                        <styled.label onChange={[Function: onChange]} error={false}>
+                                          <StyledComponent onChange={[Function: onChange]} error={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                                            <label onChange={[Function: onChange]} className=\\"sc-ckVGcZ jNBPWj\\">
+                                              <LabelText>
+                                                <styled.span>
+                                                  <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <span className=\\"sc-kGXeez fmtdbL\\">
+                                                      Company postcode
+                                                    </span>
+                                                  </StyledComponent>
+                                                </styled.span>
+                                              </LabelText>
+                                              <Input error={[undefined]} name=\\"address_postcode\\" type=\\"text\\">
+                                                <styled.input type=\\"text\\" error={[undefined]} name=\\"address_postcode\\">
+                                                  <StyledComponent type=\\"text\\" error={[undefined]} name=\\"address_postcode\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <input type=\\"text\\" name=\\"address_postcode\\" className=\\"sc-dxgOiQ KJcFQ\\" />
+                                                  </StyledComponent>
+                                                </styled.input>
+                                              </Input>
+                                            </label>
+                                          </StyledComponent>
+                                        </styled.label>
+                                      </Label>
+                                    </InputField>
+                                  </EntityFilter>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </GridCol>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </GridRow>
+                </StyledComponent>
+              </Styled(GridRow)>
+            </EntityFilterRow>
+          </div>
+        </StyledComponent>
+      </styled.div>
+    </EntityFilters>
+    <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
+      <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-iujRgT bnRApC sc-VigVT krXvSZ\\">
+                Search
+              </button>
+            </StyledComponent>
+          </styled.button>
+        </ForwardRef>
+      </StyledComponent>
+    </Search>
+  </EntitySearch>
+</EntitySearchWithDataProvider>"
+`;
+
+exports[`EntitySearch when the "Search" button has been clicked should render the component with entities 1`] = `
+"<EntitySearchWithDataProvider getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
+  <EntitySearch entities={{...}} onEntitySearch={[Function: onEntitySearch]} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
+    <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
+      <styled.div>
+        <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+          <div className=\\"sc-bAeIUo fWSbPZ\\">
+            <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
+              <Styled(GridRow)>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <GridRow className=\\"sc-bMVAic AOkMI\\">
+                    <styled.div className=\\"sc-bMVAic AOkMI\\">
+                      <StyledComponent className=\\"sc-bMVAic AOkMI\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-bMVAic AOkMI sc-hzDkRC hNOsPM\\">
+                          <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                            <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                              <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-bRBYWo cfvpGy\\">
+                                  <EntityFilter filter={{...}} setFilter={[Function: setFilter]}>
+                                    <InputField onChange={[Function: onChange]} input={{...}} hint={[undefined]} meta={{...}}>
+                                      <Label onChange={[Function: onChange]} error={false}>
+                                        <styled.label onChange={[Function: onChange]} error={false}>
+                                          <StyledComponent onChange={[Function: onChange]} error={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                                            <label onChange={[Function: onChange]} className=\\"sc-ckVGcZ jNBPWj\\">
+                                              <LabelText>
+                                                <styled.span>
+                                                  <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <span className=\\"sc-kGXeez fmtdbL\\">
+                                                      Company name
+                                                    </span>
+                                                  </StyledComponent>
+                                                </styled.span>
+                                              </LabelText>
+                                              <Input error={[undefined]} name=\\"search_term\\" type=\\"text\\">
+                                                <styled.input type=\\"text\\" error={[undefined]} name=\\"search_term\\">
+                                                  <StyledComponent type=\\"text\\" error={[undefined]} name=\\"search_term\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <input type=\\"text\\" name=\\"search_term\\" className=\\"sc-dxgOiQ KJcFQ\\" />
+                                                  </StyledComponent>
+                                                </styled.input>
+                                              </Input>
+                                            </label>
+                                          </StyledComponent>
+                                        </styled.label>
+                                      </Label>
+                                    </InputField>
+                                  </EntityFilter>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </GridCol>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </GridRow>
+                </StyledComponent>
+              </Styled(GridRow)>
+            </EntityFilterRow>
+            <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
+              <Styled(GridRow)>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <GridRow className=\\"sc-bMVAic AOkMI\\">
+                    <styled.div className=\\"sc-bMVAic AOkMI\\">
+                      <StyledComponent className=\\"sc-bMVAic AOkMI\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-bMVAic AOkMI sc-hzDkRC hNOsPM\\">
+                          <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                            <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                              <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-bRBYWo cROHUG\\">
+                                  <EntityFilter filter={{...}} setFilter={[Function: setFilter]}>
+                                    <InputField onChange={[Function: onChange]} input={{...}} hint={[undefined]} meta={{...}}>
+                                      <Label onChange={[Function: onChange]} error={false}>
+                                        <styled.label onChange={[Function: onChange]} error={false}>
+                                          <StyledComponent onChange={[Function: onChange]} error={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                                            <label onChange={[Function: onChange]} className=\\"sc-ckVGcZ jNBPWj\\">
+                                              <LabelText>
+                                                <styled.span>
+                                                  <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <span className=\\"sc-kGXeez fmtdbL\\">
+                                                      Company postcode
+                                                    </span>
+                                                  </StyledComponent>
+                                                </styled.span>
+                                              </LabelText>
+                                              <Input error={[undefined]} name=\\"address_postcode\\" type=\\"text\\">
+                                                <styled.input type=\\"text\\" error={[undefined]} name=\\"address_postcode\\">
+                                                  <StyledComponent type=\\"text\\" error={[undefined]} name=\\"address_postcode\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <input type=\\"text\\" name=\\"address_postcode\\" className=\\"sc-dxgOiQ KJcFQ\\" />
                                                   </StyledComponent>
                                                 </styled.input>
                                               </Input>
@@ -188,6 +327,69 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
         </StyledComponent>
       </styled.ol>
     </EntityList>
+    <CannotFindDetails summary=\\"cannot find summary\\" actions={{...}} link={{...}}>
+      <Details summary=\\"cannot find summary\\" open={false}>
+        <styled.details open={false}>
+          <StyledComponent open={false} forwardedComponent={{...}} forwardedRef={{...}}>
+            <details open={false} className=\\"sc-kEYyzF ihcnje\\">
+              <styled.summary>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <summary className=\\"sc-kkGfuU cCdZFh\\">
+                    <styled.span>
+                      <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                        <span className=\\"sc-iAyFgw jRkIxn\\">
+                          cannot find summary
+                        </span>
+                      </StyledComponent>
+                    </styled.span>
+                  </summary>
+                </StyledComponent>
+              </styled.summary>
+              <styled.div>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <div className=\\"sc-hSdWYo dfimje\\">
+                    <div>
+                      <Paragraph supportingText={false} linkRenderer={[Function: linkRenderer]}>
+                        <Styled(ReactMarkdown) source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]}>
+                          <StyledComponent source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]} forwardedComponent={{...}} forwardedRef={{...}}>
+                            <ReactMarkdown source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]} className=\\"sc-jAaTju fBEFVB\\" sourcePos={false} rawSourcePos={false} transformLinkUri={[Function: uriTransformer]} astPlugins={{...}} plugins={{...}} parserOptions={{...}}>
+                              <Root className=\\"sc-jAaTju fBEFVB\\">
+                                <div className=\\"sc-jAaTju fBEFVB\\">
+                                  <p>
+                                    <TextRenderer nodeKey=\\"text-1-1\\" value=\\"Try refining your search by taking the following actions:\\">
+                                      Try refining your search by taking the following actions:
+                                    </TextRenderer>
+                                  </p>
+                                </div>
+                              </Root>
+                            </ReactMarkdown>
+                          </StyledComponent>
+                        </Styled(ReactMarkdown)>
+                      </Paragraph>
+                      <ul>
+                        <li>
+                          action 1
+                        </li>
+                        <li>
+                          action 2
+                        </li>
+                      </ul>
+                      <styled.a href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} textColour={false} noVisitedState={false}>
+                        <StyledComponent href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} textColour={false} noVisitedState={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                          <a href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} className=\\"sc-bwzfXH VXMCV\\">
+                            still cannot find
+                          </a>
+                        </StyledComponent>
+                      </styled.a>
+                    </div>
+                  </div>
+                </StyledComponent>
+              </styled.div>
+            </details>
+          </StyledComponent>
+        </styled.details>
+      </Details>
+    </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
         <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\">
@@ -206,8 +408,8 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
 `;
 
 exports[`EntitySearch when the company name filter is applied should render the component with filtered entities 1`] = `
-"<EntitySearchWithDataProvider getEntities={[Function]} entityFilters={{...}}>
-  <EntitySearch entities={{...}} onEntitySearch={[Function: onEntitySearch]} getEntities={[Function]} entityFilters={{...}}>
+"<EntitySearchWithDataProvider getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
+  <EntitySearch entities={{...}} onEntitySearch={[Function: onEntitySearch]} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
@@ -242,6 +444,56 @@ exports[`EntitySearch when the company name filter is applied should render the 
                                                 <styled.input type=\\"text\\" error={[undefined]} name=\\"search_term\\">
                                                   <StyledComponent type=\\"text\\" error={[undefined]} name=\\"search_term\\" forwardedComponent={{...}} forwardedRef={{...}}>
                                                     <input type=\\"text\\" name=\\"search_term\\" className=\\"sc-dxgOiQ KJcFQ\\" />
+                                                  </StyledComponent>
+                                                </styled.input>
+                                              </Input>
+                                            </label>
+                                          </StyledComponent>
+                                        </styled.label>
+                                      </Label>
+                                    </InputField>
+                                  </EntityFilter>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </GridCol>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </GridRow>
+                </StyledComponent>
+              </Styled(GridRow)>
+            </EntityFilterRow>
+            <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
+              <Styled(GridRow)>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <GridRow className=\\"sc-bMVAic AOkMI\\">
+                    <styled.div className=\\"sc-bMVAic AOkMI\\">
+                      <StyledComponent className=\\"sc-bMVAic AOkMI\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-bMVAic AOkMI sc-hzDkRC hNOsPM\\">
+                          <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                            <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                              <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-bRBYWo cROHUG\\">
+                                  <EntityFilter filter={{...}} setFilter={[Function: setFilter]}>
+                                    <InputField onChange={[Function: onChange]} input={{...}} hint={[undefined]} meta={{...}}>
+                                      <Label onChange={[Function: onChange]} error={false}>
+                                        <styled.label onChange={[Function: onChange]} error={false}>
+                                          <StyledComponent onChange={[Function: onChange]} error={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                                            <label onChange={[Function: onChange]} className=\\"sc-ckVGcZ jNBPWj\\">
+                                              <LabelText>
+                                                <styled.span>
+                                                  <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <span className=\\"sc-kGXeez fmtdbL\\">
+                                                      Company postcode
+                                                    </span>
+                                                  </StyledComponent>
+                                                </styled.span>
+                                              </LabelText>
+                                              <Input error={[undefined]} name=\\"address_postcode\\" type=\\"text\\">
+                                                <styled.input type=\\"text\\" error={[undefined]} name=\\"address_postcode\\">
+                                                  <StyledComponent type=\\"text\\" error={[undefined]} name=\\"address_postcode\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <input type=\\"text\\" name=\\"address_postcode\\" className=\\"sc-dxgOiQ KJcFQ\\" />
                                                   </StyledComponent>
                                                 </styled.input>
                                               </Input>
@@ -314,6 +566,69 @@ exports[`EntitySearch when the company name filter is applied should render the 
         </StyledComponent>
       </styled.ol>
     </EntityList>
+    <CannotFindDetails summary=\\"cannot find summary\\" actions={{...}} link={{...}}>
+      <Details summary=\\"cannot find summary\\" open={false}>
+        <styled.details open={false}>
+          <StyledComponent open={false} forwardedComponent={{...}} forwardedRef={{...}}>
+            <details open={false} className=\\"sc-kEYyzF ihcnje\\">
+              <styled.summary>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <summary className=\\"sc-kkGfuU cCdZFh\\">
+                    <styled.span>
+                      <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                        <span className=\\"sc-iAyFgw jRkIxn\\">
+                          cannot find summary
+                        </span>
+                      </StyledComponent>
+                    </styled.span>
+                  </summary>
+                </StyledComponent>
+              </styled.summary>
+              <styled.div>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <div className=\\"sc-hSdWYo dfimje\\">
+                    <div>
+                      <Paragraph supportingText={false} linkRenderer={[Function: linkRenderer]}>
+                        <Styled(ReactMarkdown) source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]}>
+                          <StyledComponent source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]} forwardedComponent={{...}} forwardedRef={{...}}>
+                            <ReactMarkdown source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]} className=\\"sc-jAaTju fBEFVB\\" sourcePos={false} rawSourcePos={false} transformLinkUri={[Function: uriTransformer]} astPlugins={{...}} plugins={{...}} parserOptions={{...}}>
+                              <Root className=\\"sc-jAaTju fBEFVB\\">
+                                <div className=\\"sc-jAaTju fBEFVB\\">
+                                  <p>
+                                    <TextRenderer nodeKey=\\"text-1-1\\" value=\\"Try refining your search by taking the following actions:\\">
+                                      Try refining your search by taking the following actions:
+                                    </TextRenderer>
+                                  </p>
+                                </div>
+                              </Root>
+                            </ReactMarkdown>
+                          </StyledComponent>
+                        </Styled(ReactMarkdown)>
+                      </Paragraph>
+                      <ul>
+                        <li>
+                          action 1
+                        </li>
+                        <li>
+                          action 2
+                        </li>
+                      </ul>
+                      <styled.a href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} textColour={false} noVisitedState={false}>
+                        <StyledComponent href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} textColour={false} noVisitedState={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                          <a href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} className=\\"sc-bwzfXH VXMCV\\">
+                            still cannot find
+                          </a>
+                        </StyledComponent>
+                      </styled.a>
+                    </div>
+                  </div>
+                </StyledComponent>
+              </styled.div>
+            </details>
+          </StyledComponent>
+        </styled.details>
+      </Details>
+    </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
         <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\">
@@ -332,8 +647,8 @@ exports[`EntitySearch when the company name filter is applied should render the 
 `;
 
 exports[`EntitySearch when the company postcode filter is applied should render the component with filtered entities 1`] = `
-"<EntitySearchWithDataProvider getEntities={[Function]} entityFilters={{...}}>
-  <EntitySearch entities={{...}} onEntitySearch={[Function: onEntitySearch]} getEntities={[Function]} entityFilters={{...}}>
+"<EntitySearchWithDataProvider getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
+  <EntitySearch entities={{...}} onEntitySearch={[Function: onEntitySearch]} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
@@ -490,6 +805,348 @@ exports[`EntitySearch when the company postcode filter is applied should render 
         </StyledComponent>
       </styled.ol>
     </EntityList>
+    <CannotFindDetails summary=\\"cannot find summary\\" actions={{...}} link={{...}}>
+      <Details summary=\\"cannot find summary\\" open={false}>
+        <styled.details open={false}>
+          <StyledComponent open={false} forwardedComponent={{...}} forwardedRef={{...}}>
+            <details open={false} className=\\"sc-kEYyzF ihcnje\\">
+              <styled.summary>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <summary className=\\"sc-kkGfuU cCdZFh\\">
+                    <styled.span>
+                      <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                        <span className=\\"sc-iAyFgw jRkIxn\\">
+                          cannot find summary
+                        </span>
+                      </StyledComponent>
+                    </styled.span>
+                  </summary>
+                </StyledComponent>
+              </styled.summary>
+              <styled.div>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <div className=\\"sc-hSdWYo dfimje\\">
+                    <div>
+                      <Paragraph supportingText={false} linkRenderer={[Function: linkRenderer]}>
+                        <Styled(ReactMarkdown) source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]}>
+                          <StyledComponent source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]} forwardedComponent={{...}} forwardedRef={{...}}>
+                            <ReactMarkdown source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]} className=\\"sc-jAaTju fBEFVB\\" sourcePos={false} rawSourcePos={false} transformLinkUri={[Function: uriTransformer]} astPlugins={{...}} plugins={{...}} parserOptions={{...}}>
+                              <Root className=\\"sc-jAaTju fBEFVB\\">
+                                <div className=\\"sc-jAaTju fBEFVB\\">
+                                  <p>
+                                    <TextRenderer nodeKey=\\"text-1-1\\" value=\\"Try refining your search by taking the following actions:\\">
+                                      Try refining your search by taking the following actions:
+                                    </TextRenderer>
+                                  </p>
+                                </div>
+                              </Root>
+                            </ReactMarkdown>
+                          </StyledComponent>
+                        </Styled(ReactMarkdown)>
+                      </Paragraph>
+                      <ul>
+                        <li>
+                          action 1
+                        </li>
+                        <li>
+                          action 2
+                        </li>
+                      </ul>
+                      <styled.a href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} textColour={false} noVisitedState={false}>
+                        <StyledComponent href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} textColour={false} noVisitedState={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                          <a href=\\"http://stillcannotfind.com\\" onClick={{...}} muted={false} className=\\"sc-bwzfXH VXMCV\\">
+                            still cannot find
+                          </a>
+                        </StyledComponent>
+                      </styled.a>
+                    </div>
+                  </div>
+                </StyledComponent>
+              </styled.div>
+            </details>
+          </StyledComponent>
+        </styled.details>
+      </Details>
+    </CannotFindDetails>
+    <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
+      <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-iujRgT bnRApC sc-VigVT krXvSZ\\">
+                Search
+              </button>
+            </StyledComponent>
+          </styled.button>
+        </ForwardRef>
+      </StyledComponent>
+    </Search>
+  </EntitySearch>
+</EntitySearchWithDataProvider>"
+`;
+
+exports[`EntitySearch when the the cannot find link has a callback should render the component 1`] = `
+"<EntitySearchWithDataProvider getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
+  <EntitySearch entities={{...}} onEntitySearch={[Function: onEntitySearch]} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}}>
+    <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
+      <styled.div>
+        <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+          <div className=\\"sc-bAeIUo fWSbPZ\\">
+            <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
+              <Styled(GridRow)>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <GridRow className=\\"sc-bMVAic AOkMI\\">
+                    <styled.div className=\\"sc-bMVAic AOkMI\\">
+                      <StyledComponent className=\\"sc-bMVAic AOkMI\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-bMVAic AOkMI sc-hzDkRC hNOsPM\\">
+                          <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                            <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                              <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-bRBYWo cfvpGy\\">
+                                  <EntityFilter filter={{...}} setFilter={[Function: setFilter]}>
+                                    <InputField onChange={[Function: onChange]} input={{...}} hint={[undefined]} meta={{...}}>
+                                      <Label onChange={[Function: onChange]} error={false}>
+                                        <styled.label onChange={[Function: onChange]} error={false}>
+                                          <StyledComponent onChange={[Function: onChange]} error={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                                            <label onChange={[Function: onChange]} className=\\"sc-ckVGcZ jNBPWj\\">
+                                              <LabelText>
+                                                <styled.span>
+                                                  <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <span className=\\"sc-kGXeez fmtdbL\\">
+                                                      Company name
+                                                    </span>
+                                                  </StyledComponent>
+                                                </styled.span>
+                                              </LabelText>
+                                              <Input error={[undefined]} name=\\"search_term\\" type=\\"text\\">
+                                                <styled.input type=\\"text\\" error={[undefined]} name=\\"search_term\\">
+                                                  <StyledComponent type=\\"text\\" error={[undefined]} name=\\"search_term\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <input type=\\"text\\" name=\\"search_term\\" className=\\"sc-dxgOiQ KJcFQ\\" />
+                                                  </StyledComponent>
+                                                </styled.input>
+                                              </Input>
+                                            </label>
+                                          </StyledComponent>
+                                        </styled.label>
+                                      </Label>
+                                    </InputField>
+                                  </EntityFilter>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </GridCol>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </GridRow>
+                </StyledComponent>
+              </Styled(GridRow)>
+            </EntityFilterRow>
+            <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
+              <Styled(GridRow)>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <GridRow className=\\"sc-bMVAic AOkMI\\">
+                    <styled.div className=\\"sc-bMVAic AOkMI\\">
+                      <StyledComponent className=\\"sc-bMVAic AOkMI\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-bMVAic AOkMI sc-hzDkRC hNOsPM\\">
+                          <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                            <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                              <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-bRBYWo cROHUG\\">
+                                  <EntityFilter filter={{...}} setFilter={[Function: setFilter]}>
+                                    <InputField onChange={[Function: onChange]} input={{...}} hint={[undefined]} meta={{...}}>
+                                      <Label onChange={[Function: onChange]} error={false}>
+                                        <styled.label onChange={[Function: onChange]} error={false}>
+                                          <StyledComponent onChange={[Function: onChange]} error={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                                            <label onChange={[Function: onChange]} className=\\"sc-ckVGcZ jNBPWj\\">
+                                              <LabelText>
+                                                <styled.span>
+                                                  <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <span className=\\"sc-kGXeez fmtdbL\\">
+                                                      Company postcode
+                                                    </span>
+                                                  </StyledComponent>
+                                                </styled.span>
+                                              </LabelText>
+                                              <Input error={[undefined]} name=\\"address_postcode\\" type=\\"text\\">
+                                                <styled.input type=\\"text\\" error={[undefined]} name=\\"address_postcode\\">
+                                                  <StyledComponent type=\\"text\\" error={[undefined]} name=\\"address_postcode\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <input type=\\"text\\" name=\\"address_postcode\\" className=\\"sc-dxgOiQ KJcFQ\\" />
+                                                  </StyledComponent>
+                                                </styled.input>
+                                              </Input>
+                                            </label>
+                                          </StyledComponent>
+                                        </styled.label>
+                                      </Label>
+                                    </InputField>
+                                  </EntityFilter>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </GridCol>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </GridRow>
+                </StyledComponent>
+              </Styled(GridRow)>
+            </EntityFilterRow>
+          </div>
+        </StyledComponent>
+      </styled.div>
+    </EntityFilters>
+    <EntityList entities={{...}}>
+      <styled.ol>
+        <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+          <ol className=\\"sc-cmthru byZYSx\\">
+            <styled.li>
+              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                <li className=\\"sc-hMFtBS hNLTdh\\">
+                  <styled.div>
+                    <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div className=\\"sc-cLQEGU kGDauh\\">
+                        <Styled(H3)>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <H3 className=\\"sc-gqPbQI gHietI\\">
+                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gqPbQI gHietI\\" level={[undefined]}>
+                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gqPbQI gHietI\\">
+                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gqPbQI gHietI\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                    <h3 size=\\"MEDIUM\\" className=\\"sc-gqPbQI gHietI sc-cMljjf kCLKvB\\">
+                                      Some company name
+                                    </h3>
+                                  </StyledComponent>
+                                </styled.h1>
+                              </Heading>
+                            </H3>
+                          </StyledComponent>
+                        </Styled(H3)>
+                        <styled.div>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <div className=\\"sc-hORach kZtTta\\">
+                              <span>
+                                Address
+                                : 
+                              </span>
+                              <span>
+                                123 Fake Street, Brighton, BN1 4SE
+                              </span>
+                            </div>
+                          </StyledComponent>
+                        </styled.div>
+                      </div>
+                    </StyledComponent>
+                  </styled.div>
+                </li>
+              </StyledComponent>
+            </styled.li>
+            <styled.li>
+              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                <li className=\\"sc-hMFtBS hNLTdh\\">
+                  <styled.div>
+                    <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div className=\\"sc-cLQEGU kGDauh\\">
+                        <Styled(H3)>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <H3 className=\\"sc-gqPbQI gHietI\\">
+                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gqPbQI gHietI\\" level={[undefined]}>
+                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gqPbQI gHietI\\">
+                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gqPbQI gHietI\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                    <h3 size=\\"MEDIUM\\" className=\\"sc-gqPbQI gHietI sc-cMljjf kCLKvB\\">
+                                      Some other company
+                                    </h3>
+                                  </StyledComponent>
+                                </styled.h1>
+                              </Heading>
+                            </H3>
+                          </StyledComponent>
+                        </Styled(H3)>
+                        <styled.div>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <div className=\\"sc-hORach kZtTta\\">
+                              <span>
+                                Address
+                                : 
+                              </span>
+                              <span>
+                                123 ABC Road, Brighton, BN2 9QB
+                              </span>
+                            </div>
+                          </StyledComponent>
+                        </styled.div>
+                      </div>
+                    </StyledComponent>
+                  </styled.div>
+                </li>
+              </StyledComponent>
+            </styled.li>
+          </ol>
+        </StyledComponent>
+      </styled.ol>
+    </EntityList>
+    <CannotFindDetails summary=\\"cannot find summary\\" actions={{...}} link={{...}}>
+      <Details summary=\\"cannot find summary\\" open={false}>
+        <styled.details open={false}>
+          <StyledComponent open={false} forwardedComponent={{...}} forwardedRef={{...}}>
+            <details open={false} className=\\"sc-kEYyzF ihcnje\\">
+              <styled.summary>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <summary className=\\"sc-kkGfuU cCdZFh\\">
+                    <styled.span>
+                      <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                        <span className=\\"sc-iAyFgw jRkIxn\\">
+                          cannot find summary
+                        </span>
+                      </StyledComponent>
+                    </styled.span>
+                  </summary>
+                </StyledComponent>
+              </styled.summary>
+              <styled.div>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <div className=\\"sc-hSdWYo dfimje\\">
+                    <div>
+                      <Paragraph supportingText={false} linkRenderer={[Function: linkRenderer]}>
+                        <Styled(ReactMarkdown) source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]}>
+                          <StyledComponent source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]} forwardedComponent={{...}} forwardedRef={{...}}>
+                            <ReactMarkdown source=\\"Try refining your search by taking the following actions:\\" escapeHtml={false} skipHtml={true} allowedTypes={{...}} renderers={{...}} supportingText={false} linkRenderer={[Function: linkRenderer]} className=\\"sc-jAaTju fBEFVB\\" sourcePos={false} rawSourcePos={false} transformLinkUri={[Function: uriTransformer]} astPlugins={{...}} plugins={{...}} parserOptions={{...}}>
+                              <Root className=\\"sc-jAaTju fBEFVB\\">
+                                <div className=\\"sc-jAaTju fBEFVB\\">
+                                  <p>
+                                    <TextRenderer nodeKey=\\"text-1-1\\" value=\\"Try refining your search by taking the following actions:\\">
+                                      Try refining your search by taking the following actions:
+                                    </TextRenderer>
+                                  </p>
+                                </div>
+                              </Root>
+                            </ReactMarkdown>
+                          </StyledComponent>
+                        </Styled(ReactMarkdown)>
+                      </Paragraph>
+                      <ul>
+                        <li>
+                          action 1
+                        </li>
+                        <li>
+                          action 2
+                        </li>
+                      </ul>
+                      <styled.a href=\\"#\\" onClick={[Function: onLinkClick]} muted={false} textColour={false} noVisitedState={false}>
+                        <StyledComponent href=\\"#\\" onClick={[Function: onLinkClick]} muted={false} textColour={false} noVisitedState={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                          <a href=\\"#\\" onClick={[Function: onLinkClick]} muted={false} className=\\"sc-bwzfXH VXMCV\\">
+                            still cannot find
+                          </a>
+                        </StyledComponent>
+                      </styled.a>
+                    </div>
+                  </div>
+                </StyledComponent>
+              </styled.div>
+            </details>
+          </StyledComponent>
+        </styled.details>
+      </Details>
+    </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
         <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-iujRgT bnRApC\\">


### PR DESCRIPTION
## Description of change
Adds the "cannot find" footer for when the user cannot find the entity they are looking for. The footer guides them through correcting the problem.

## Screenshots
### Before
![Screenshot 2019-08-15 at 22 05 19](https://user-images.githubusercontent.com/1150417/63126868-cca09e00-bfa8-11e9-9616-1c7371d42a88.png)

### After
![Screenshot 2019-08-15 at 22 05 05](https://user-images.githubusercontent.com/1150417/63126870-d1655200-bfa8-11e9-9efd-0bafaaf9cd3d.png)
