### PR TITLE
ci: Add `gh-pages` to ignored branches in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,4 +30,8 @@ workflows:
   version: 2
   build:
     jobs:
-      - build
+      - build:
+          filters:
+            branches:
+              ignore:
+                - gh-pages


### PR DESCRIPTION
There is no need to run CI on our storybook branch.

Example failing task: https://circleci.com/gh/uktrade/data-hub-components/697