### PR TITLE
refactor: Define prop type for entities

### DIFF
--- a/src/entity-search/EntityList.jsx
+++ b/src/entity-search/EntityList.jsx
@@ -61,7 +61,10 @@ const EntityList = ({ entities }) => {
 }
 
 EntityList.propTypes = {
-  entities: PropTypes.array.isRequired,
+  entities: PropTypes.arrayOf(PropTypes.shape({
+    heading: PropTypes.string.isRequired,
+    meta: PropTypes.object.isRequired,
+  })).isRequired,
 }
 
 export default EntityList


### PR DESCRIPTION
Missing prop type definition for `entities`.