### PR TITLE
refactor: Reuse grey constant from govuk-colours

### DIFF
--- a/src/activity-feed/__snapshots__/ActivityFeed.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeed.test.jsx.snap
@@ -382,7 +382,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
   >
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -629,7 +629,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -876,7 +876,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -1123,7 +1123,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -1370,7 +1370,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -1617,7 +1617,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -1864,7 +1864,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -2111,7 +2111,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -2358,7 +2358,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -2605,7 +2605,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -2852,7 +2852,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -3099,7 +3099,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -3346,7 +3346,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -3593,7 +3593,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -3840,7 +3840,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -4087,7 +4087,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -4334,7 +4334,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -4581,7 +4581,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -4828,7 +4828,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -5075,7 +5075,7 @@ exports[`ActivityFeed when there are more activities to load should render with 
     </li>
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"
@@ -5583,7 +5583,7 @@ exports[`ActivityFeed when there is a single activity should render single activ
   >
     <li>
       <div
-        className="sc-cmthru jjutsD"
+        className="sc-cmthru khhKab"
       >
         <div
           className="sc-cLQEGU kmbhXR"

--- a/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
+++ b/src/activity-feed/__snapshots__/ActivityFeedCard.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`ActivityFeedCard when a New OMIS order is added should render an activity card 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -213,7 +213,7 @@ exports[`ActivityFeedCard when a New OMIS order is added should render an activi
 
 exports[`ActivityFeedCard when an investment project is CTI should render the CTI investment project activity card 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -380,7 +380,7 @@ exports[`ActivityFeedCard when an investment project is CTI should render the CT
 
 exports[`ActivityFeedCard when an investment project is FDI should render the FDI investment project activity card 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -681,7 +681,7 @@ exports[`ActivityFeedCard when an investment project is FDI should render the FD
 
 exports[`ActivityFeedCard when an investment project is Non-FDI should render the Non-FDI investment project activity card 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -892,7 +892,7 @@ exports[`ActivityFeedCard when an investment project is Non-FDI should render th
 
 exports[`ActivityFeedCard when the interaction does not have a service should render interaction activity without services 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -1021,7 +1021,7 @@ exports[`ActivityFeedCard when the interaction does not have a service should re
 
 exports[`ActivityFeedCard when the interaction is a draft and archived should render interaction activity with "Cancelled interaction" badge 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -1269,7 +1269,7 @@ exports[`ActivityFeedCard when the interaction is a draft and archived should re
 
 exports[`ActivityFeedCard when the interaction is a draft and upcoming should render interaction activity with "Upcoming interaction" badge 1`] = `
 <div
-  className="sc-bdVaJa cIbqez"
+  className="sc-bdVaJa jdEOnP"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -1517,7 +1517,7 @@ exports[`ActivityFeedCard when the interaction is a draft and upcoming should re
 
 exports[`ActivityFeedCard when the interaction is a draft in the past should render interaction activity with "Incomplete interaction" badge 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -1765,7 +1765,7 @@ exports[`ActivityFeedCard when the interaction is a draft in the past should ren
 
 exports[`ActivityFeedCard when the interaction is complete should render interaction activity with "Completed interaction" badge 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -2013,7 +2013,7 @@ exports[`ActivityFeedCard when the interaction is complete should render interac
 
 exports[`ActivityFeedCard when there is a Companies House Accounts record should render an activity card 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -2217,7 +2217,7 @@ exports[`ActivityFeedCard when there is a Companies House Accounts record should
 
 exports[`ActivityFeedCard when there is a Companies House Company incorporation record should render an activity card 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -2474,7 +2474,7 @@ exports[`ActivityFeedCard when there is a Companies House Company incorporation 
 
 exports[`ActivityFeedCard when there is a HMRC Exporter record should render an activity card 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -2601,7 +2601,7 @@ exports[`ActivityFeedCard when there is a HMRC Exporter record should render an 
 
 exports[`ActivityFeedCard when there is a service delivery should render service delivery activity 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -2788,7 +2788,7 @@ exports[`ActivityFeedCard when there is an activity item of unknown type should 
 
 exports[`ActivityFeedCard when there is an interaction should render interaction activity 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"
@@ -3036,7 +3036,7 @@ exports[`ActivityFeedCard when there is an interaction should render interaction
 
 exports[`ActivityFeedCard when there is an interaction without any people involved should render interaction activity without advisers nor contacts 1`] = `
 <div
-  className="sc-bdVaJa bitMfj"
+  className="sc-bdVaJa effyms"
 >
   <div
     className="sc-cLQEGU kmbhXR"

--- a/src/activity-feed/activity-feed-cards/card/Card.jsx
+++ b/src/activity-feed/activity-feed-cards/card/Card.jsx
@@ -2,9 +2,10 @@ import React from 'react'
 import styled from 'styled-components'
 import { SPACING } from '@govuk-react/constants'
 import PropTypes from 'prop-types'
+import { GREY_2 } from 'govuk-colours'
 
 const CardContainer = styled('div')`
-  border: ${({ isUpcoming }) => (isUpcoming ? '1px dashed #c0c0c0' : '1px solid #c0c0c0')};
+  border: ${({ isUpcoming }) => (isUpcoming ? `1px dashed ${GREY_2}` : `1px solid ${GREY_2}`)};
   padding: ${SPACING.SCALE_3};
 `
 


### PR DESCRIPTION
## Description of change
Activity feed was using an arbitrary grey `#c0c0c0`. This change reuses the `GREY` from `govuk-colours`.

## Test instructions
Check the borders at `/?path=/story/activityfeed--data-hub-company-page`

The visual difference is subtle as the previous value was not specified by GDS.