### PR TITLE
feat: Show message when no entities returned

### DIFF
--- a/src/entity-search/EntityList.jsx
+++ b/src/entity-search/EntityList.jsx
@@ -78,8 +78,12 @@ EntityList.propTypes = {
   entities: PropTypes.arrayOf(PropTypes.shape({
     heading: PropTypes.string.isRequired,
     meta: PropTypes.object.isRequired,
-  })).isRequired,
+  })),
   onEntityClick: PropTypes.func.isRequired,
+}
+
+EntityList.defaultProps = {
+  entities: null,
 }
 
 export default EntityList

--- a/src/entity-search/EntitySearch.jsx
+++ b/src/entity-search/EntitySearch.jsx
@@ -38,6 +38,10 @@ const EntitySearch = ({
         </>
       ) : null}
 
+      {entities && entities.length === 0 ? (
+        <p>There are no entities to show.</p>
+      ) : null}
+
       {error && <p>{error}</p>}
 
       <StyledButton onClick={() => onEntitySearch(filters)}>Search</StyledButton>
@@ -49,7 +53,7 @@ EntitySearch.propTypes = {
   entities: PropTypes.arrayOf(PropTypes.shape({
     heading: PropTypes.string.isRequired,
     meta: PropTypes.object.isRequired,
-  })).isRequired,
+  })),
   onEntitySearch: PropTypes.func.isRequired,
   entityFilters: PropTypes.array.isRequired,
   cannotFind: PropTypes.shape({
@@ -70,6 +74,7 @@ EntitySearch.propTypes = {
 }
 
 EntitySearch.defaultProps = {
+  entities: null,
   previouslySelected: null,
   error: null,
 }

--- a/src/entity-search/EntitySearch.stories.jsx
+++ b/src/entity-search/EntitySearch.stories.jsx
@@ -15,9 +15,9 @@ const mock = new MockAdapter(axios)
 const apiEndpoint = 'http://localhost:3010/v4/dnb/company-search'
 const apiEndpointWithParameters = new RegExp(`${apiEndpoint}.+`)
 
-const setupSuccessMocks = () => {
-  mock.onPost(apiEndpoint).reply(200, fixtures.companySearch)
-  mock.onPost(apiEndpointWithParameters).reply(200, fixtures.companySearch)
+const setupSuccessMocks = (response = fixtures.companySearch) => {
+  mock.onPost(apiEndpoint).reply(200, response)
+  mock.onPost(apiEndpointWithParameters).reply(200, response)
 }
 
 const setupErrorMocks = () => {
@@ -120,6 +120,13 @@ storiesOf('EntitySearch', module)
   })
   .add('Data Hub company search with server error', () => {
     setupErrorMocks()
+
+    return (
+      <EntitySearchForStorybook />
+    )
+  })
+  .add('Data Hub company search with no results', () => {
+    setupSuccessMocks(fixtures.companySearchNoResults)
 
     return (
       <EntitySearchForStorybook />

--- a/src/entity-search/EntitySearch.test.jsx
+++ b/src/entity-search/EntitySearch.test.jsx
@@ -258,4 +258,22 @@ describe('EntitySearch', () => {
       expect(wrappedEntitySearch.debug()).toMatchSnapshot()
     })
   })
+
+  describe('when the API returns 0 results', () => {
+    beforeAll(() => {
+      mock.onPost(API_ENDPOINT).reply(200, fixtures.companySearchNoResults)
+    })
+
+    test('should render the component with a "no entities" message', async () => {
+      const wrappedEntitySearch = wrapEntitySearch()
+
+      wrappedEntitySearch.find('Search').simulate('click')
+
+      await act(flushPromises)
+
+      wrappedEntitySearch.update()
+
+      expect(wrappedEntitySearch.debug()).toMatchSnapshot()
+    })
+  })
 })

--- a/src/entity-search/EntitySearchWithDataProvider.jsx
+++ b/src/entity-search/EntitySearchWithDataProvider.jsx
@@ -5,7 +5,7 @@ import EntitySearch from './EntitySearch'
 
 const EntitySearchWithDataProvider = (props) => {
   const { getEntities } = props
-  const [entities, setEntities] = useState([])
+  const [entities, setEntities] = useState(null)
   const [error, setError] = useState(null)
   const onEntitySearch = async (filters) => {
     try {

--- a/src/entity-search/__snapshots__/EntitySearch.test.jsx.snap
+++ b/src/entity-search/__snapshots__/EntitySearch.test.jsx.snap
@@ -411,6 +411,137 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
 </EntitySearchWithDataProvider>"
 `;
 
+exports[`EntitySearch when the API returns 0 results should render the component with a "no entities" message 1`] = `
+"<EntitySearchWithDataProvider previouslySelected={[undefined]} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}} onEntityClick={[Function]}>
+  <EntitySearch entities={{...}} error={{...}} onEntitySearch={[Function: onEntitySearch]} previouslySelected={{...}} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}} onEntityClick={[Function]}>
+    <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
+      <styled.div>
+        <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+          <div className=\\"sc-iujRgT iFtdxx\\">
+            <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
+              <Styled(GridRow)>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <GridRow className=\\"sc-bAeIUo bPwEFe\\">
+                    <styled.div className=\\"sc-bAeIUo bPwEFe\\">
+                      <StyledComponent className=\\"sc-bAeIUo bPwEFe\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-bAeIUo bPwEFe sc-hzDkRC hNOsPM\\">
+                          <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                            <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                              <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-bRBYWo cfvpGy\\">
+                                  <EntityFilter filter={{...}} setFilter={[Function: setFilter]}>
+                                    <InputField onChange={[Function: onChange]} input={{...}} hint={[undefined]} meta={{...}}>
+                                      <Label onChange={[Function: onChange]} error={false}>
+                                        <styled.label onChange={[Function: onChange]} error={false}>
+                                          <StyledComponent onChange={[Function: onChange]} error={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                                            <label onChange={[Function: onChange]} className=\\"sc-ckVGcZ jNBPWj\\">
+                                              <LabelText>
+                                                <styled.span>
+                                                  <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <span className=\\"sc-kGXeez fmtdbL\\">
+                                                      Company name
+                                                    </span>
+                                                  </StyledComponent>
+                                                </styled.span>
+                                              </LabelText>
+                                              <Input error={[undefined]} name=\\"search_term\\" type=\\"text\\">
+                                                <styled.input type=\\"text\\" error={[undefined]} name=\\"search_term\\">
+                                                  <StyledComponent type=\\"text\\" error={[undefined]} name=\\"search_term\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <input type=\\"text\\" name=\\"search_term\\" className=\\"sc-dxgOiQ KJcFQ\\" />
+                                                  </StyledComponent>
+                                                </styled.input>
+                                              </Input>
+                                            </label>
+                                          </StyledComponent>
+                                        </styled.label>
+                                      </Label>
+                                    </InputField>
+                                  </EntityFilter>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </GridCol>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </GridRow>
+                </StyledComponent>
+              </Styled(GridRow)>
+            </EntityFilterRow>
+            <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
+              <Styled(GridRow)>
+                <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                  <GridRow className=\\"sc-bAeIUo bPwEFe\\">
+                    <styled.div className=\\"sc-bAeIUo bPwEFe\\">
+                      <StyledComponent className=\\"sc-bAeIUo bPwEFe\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-bAeIUo bPwEFe sc-hzDkRC hNOsPM\\">
+                          <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                            <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
+                              <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-bRBYWo cROHUG\\">
+                                  <EntityFilter filter={{...}} setFilter={[Function: setFilter]}>
+                                    <InputField onChange={[Function: onChange]} input={{...}} hint={[undefined]} meta={{...}}>
+                                      <Label onChange={[Function: onChange]} error={false}>
+                                        <styled.label onChange={[Function: onChange]} error={false}>
+                                          <StyledComponent onChange={[Function: onChange]} error={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                                            <label onChange={[Function: onChange]} className=\\"sc-ckVGcZ jNBPWj\\">
+                                              <LabelText>
+                                                <styled.span>
+                                                  <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <span className=\\"sc-kGXeez fmtdbL\\">
+                                                      Company postcode
+                                                    </span>
+                                                  </StyledComponent>
+                                                </styled.span>
+                                              </LabelText>
+                                              <Input error={[undefined]} name=\\"address_postcode\\" type=\\"text\\">
+                                                <styled.input type=\\"text\\" error={[undefined]} name=\\"address_postcode\\">
+                                                  <StyledComponent type=\\"text\\" error={[undefined]} name=\\"address_postcode\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                                    <input type=\\"text\\" name=\\"address_postcode\\" className=\\"sc-dxgOiQ KJcFQ\\" />
+                                                  </StyledComponent>
+                                                </styled.input>
+                                              </Input>
+                                            </label>
+                                          </StyledComponent>
+                                        </styled.label>
+                                      </Label>
+                                    </InputField>
+                                  </EntityFilter>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </GridCol>
+                        </div>
+                      </StyledComponent>
+                    </styled.div>
+                  </GridRow>
+                </StyledComponent>
+              </Styled(GridRow)>
+            </EntityFilterRow>
+          </div>
+        </StyledComponent>
+      </styled.div>
+    </EntityFilters>
+    <p>
+      There are no entities to show.
+    </p>
+    <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
+      <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-exAgwC iIVHNj\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-exAgwC iIVHNj\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-exAgwC iIVHNj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-exAgwC iIVHNj sc-VigVT krXvSZ\\">
+                Search
+              </button>
+            </StyledComponent>
+          </styled.button>
+        </ForwardRef>
+      </StyledComponent>
+    </Search>
+  </EntitySearch>
+</EntitySearchWithDataProvider>"
+`;
+
 exports[`EntitySearch when the API returns a server error should render the component with an error message 1`] = `
 "<EntitySearchWithDataProvider previouslySelected={[undefined]} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}} onEntityClick={[Function]}>
   <EntitySearch entities={{...}} error=\\"Error occurred while searching entities.\\" onEntitySearch={[Function: onEntitySearch]} previouslySelected={{...}} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}} onEntityClick={[Function]}>

--- a/src/entity-search/fixtures/company-search-no-results.json
+++ b/src/entity-search/fixtures/company-search-no-results.json
@@ -1,0 +1,7 @@
+{
+  "total_matches": 0,
+  "total_returned": 0,
+  "page_size": 0,
+  "page_number": 1,
+  "results": []
+}

--- a/src/entity-search/fixtures/index.js
+++ b/src/entity-search/fixtures/index.js
@@ -1,9 +1,11 @@
 import companySearch from './company-search'
+import companySearchNoResults from './company-search-no-results'
 import companySearchFilteredByPostcode from './company-search-postcode-BN1-4SE'
 import companySearchFilteredByCompanyName from './company-search-some-other-company'
 
 export default {
   companySearch,
+  companySearchNoResults,
   companySearchFilteredByPostcode,
   companySearchFilteredByCompanyName,
 }


### PR DESCRIPTION
## Description of change
When no entities are returned from the API request, a friendly message should be presented to the user rather than nothing at all.

## Test instructions
1. Browse to `/?path=/story/entitysearch--data-hub-company-search-with-no-results`
2. Click `Search`. You should see `There are no entities to show.`

## Screenshot
<img width="989" alt="Screenshot 2019-08-22 at 14 01 09" src="https://user-images.githubusercontent.com/1150417/63516688-5e4a6700-c4e5-11e9-8fd0-ca49ff8a012d.png">
