### PR TITLE
Present text when entity is known, handle click event differently

### DIFF
--- a/src/entity-search/EntityList.jsx
+++ b/src/entity-search/EntityList.jsx
@@ -2,9 +2,15 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
-import { GREY_2, GREY_4, LINK_COLOUR, LINK_HOVER_COLOUR, SECONDARY_TEXT_COLOUR } from 'govuk-colours'
+import {
+  GREY_2,
+  GREY_4,
+  LINK_COLOUR,
+  LINK_HOVER_COLOUR,
+  SECONDARY_TEXT_COLOUR,
+} from 'govuk-colours'
 import { uniqueId } from 'lodash'
-import { H3 } from 'govuk-react'
+import { H3, InsetText } from 'govuk-react'
 
 const StyledEntityList = styled('ol')`
   margin: ${SPACING.SCALE_2} 0 ${SPACING.SCALE_4} 0;
@@ -21,14 +27,16 @@ const StyledEntity = styled('div')`
   border: 1px solid ${GREY_2};  
   cursor: pointer;
   
-  &:hover {
-    border: 1px solid ${LINK_HOVER_COLOUR};
-    background-color: ${GREY_4};
-    
-    & > h3 {
-      color: ${LINK_HOVER_COLOUR};
+  ${({ canHandleClick }) => canHandleClick && `
+    &:hover {
+      border: 1px solid ${LINK_HOVER_COLOUR};
+      background-color: ${GREY_4};
+      
+      & > h3 {
+        color: ${LINK_HOVER_COLOUR};
+      }
     }
-  }
+  `}
 `
 StyledEntity.displayName = 'StyledEntity'
 
@@ -52,20 +60,31 @@ const StyledMetaItem = styled('div')`
   }
 `
 
+const StyledInsetText = styled(InsetText)`
+  & {
+    margin-top: ${SPACING.SCALE_2};
+  }
+`
+
 const EntityList = ({ entities, onEntityClick }) => {
   return (
     <StyledEntityList>
-      {entities.map((entity) => {
+      {entities.map(({ canHandleClick, data, heading, meta, text }) => {
         return (
           <StyledEntityListItem key={uniqueId()}>
-            <StyledEntity key={uniqueId()} onClick={() => onEntityClick(entity)}>
-              <StyledHeading>{entity.heading}</StyledHeading>
-              {Object.keys(entity.meta).map(metaKey => (
+            <StyledEntity
+              key={uniqueId()}
+              onClick={() => canHandleClick && onEntityClick(data)}
+              canHandleClick={canHandleClick}
+            >
+              <StyledHeading>{heading}</StyledHeading>
+              {Object.keys(meta).map(metaKey => (
                 <StyledMetaItem key={uniqueId()}>
                   <span>{metaKey}:</span>
-                  <span>{entity.meta[metaKey]}</span>
+                  <span>{meta[metaKey]}</span>
                 </StyledMetaItem>
               ))}
+              {text && <StyledInsetText>{text}</StyledInsetText>}
             </StyledEntity>
           </StyledEntityListItem>
         )
@@ -76,6 +95,9 @@ const EntityList = ({ entities, onEntityClick }) => {
 
 EntityList.propTypes = {
   entities: PropTypes.arrayOf(PropTypes.shape({
+    data: PropTypes.object.isRequired,
+    canHandleClick: PropTypes.bool.isRequired,
+    text: PropTypes.node,
     heading: PropTypes.string.isRequired,
     meta: PropTypes.object.isRequired,
   })),

--- a/src/entity-search/EntityList.jsx
+++ b/src/entity-search/EntityList.jsx
@@ -1,16 +1,10 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import { SPACING, FONT_SIZE, MEDIA_QUERIES } from '@govuk-react/constants'
-import {
-  GREY_2,
-  GREY_4,
-  LINK_COLOUR,
-  LINK_HOVER_COLOUR,
-  SECONDARY_TEXT_COLOUR,
-} from 'govuk-colours'
+import { SPACING } from '@govuk-react/constants'
 import { uniqueId } from 'lodash'
-import { H3, InsetText } from 'govuk-react'
+
+import EntityListItem from './EntityListItem'
 
 const StyledEntityList = styled('ol')`
   margin: ${SPACING.SCALE_2} 0 ${SPACING.SCALE_4} 0;
@@ -21,71 +15,13 @@ const StyledEntityListItem = styled('li')`
   list-style-type: none;
 `
 
-const StyledEntity = styled('div')`
-  margin-bottom: ${SPACING.SCALE_2};
-  padding: ${SPACING.SCALE_2};
-  border: 1px solid ${GREY_2};  
-  cursor: pointer;
-  
-  ${({ canHandleClick }) => canHandleClick && `
-    &:hover {
-      border: 1px solid ${LINK_HOVER_COLOUR};
-      background-color: ${GREY_4};
-      
-      & > h3 {
-        color: ${LINK_HOVER_COLOUR};
-      }
-    }
-  `}
-`
-StyledEntity.displayName = 'StyledEntity'
-
-const StyledHeading = styled(H3)`
-  margin: 0;
-  color: ${LINK_COLOUR};
-  font-size: ${FONT_SIZE.SIZE_16};
-  ${MEDIA_QUERIES.TABLET} {
-    font-size: ${FONT_SIZE.SIZE_19};
-  }
-`
-
-const StyledMetaItem = styled('div')`
-  list-style-type: none;
-  margin-top: ${SPACING.SCALE_2};
-  font-size: ${FONT_SIZE.SIZE_16};
-    
-  & > span:nth-child(1) {
-    color: ${SECONDARY_TEXT_COLOUR};
-    margin-right: ${SPACING.SCALE_1}
-  }
-`
-
-const StyledInsetText = styled(InsetText)`
-  & {
-    margin-top: ${SPACING.SCALE_2};
-  }
-`
-
 const EntityList = ({ entities, onEntityClick }) => {
   return (
     <StyledEntityList>
-      {entities.map(({ canHandleClick, data, heading, meta, text }) => {
+      {entities.map((entity) => {
         return (
           <StyledEntityListItem key={uniqueId()}>
-            <StyledEntity
-              key={uniqueId()}
-              onClick={() => canHandleClick && onEntityClick(data)}
-              canHandleClick={canHandleClick}
-            >
-              <StyledHeading>{heading}</StyledHeading>
-              {Object.keys(meta).map(metaKey => (
-                <StyledMetaItem key={uniqueId()}>
-                  <span>{metaKey}:</span>
-                  <span>{meta[metaKey]}</span>
-                </StyledMetaItem>
-              ))}
-              {text && <StyledInsetText>{text}</StyledInsetText>}
-            </StyledEntity>
+            <EntityListItem onEntityClick={onEntityClick} {...entity} />
           </StyledEntityListItem>
         )
       })}

--- a/src/entity-search/EntityListItem.jsx
+++ b/src/entity-search/EntityListItem.jsx
@@ -1,0 +1,75 @@
+import { uniqueId } from 'lodash'
+import React from 'react'
+import styled from 'styled-components'
+import { FONT_SIZE, MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
+import { GREY_2, GREY_4, LINK_COLOUR, LINK_HOVER_COLOUR } from 'govuk-colours'
+import { H3, InsetText } from 'govuk-react'
+import PropTypes from 'prop-types'
+
+import EntityListItemMetaList from './EntityListItemMetaList'
+
+const StyledEntity = styled('div')`
+  margin-bottom: ${SPACING.SCALE_2};
+  padding: ${SPACING.SCALE_2};
+  border: 1px solid ${GREY_2};  
+  
+  ${({ canHandleClick }) => canHandleClick && `
+    cursor: pointer;
+
+    &:hover {
+      border: 1px solid ${LINK_HOVER_COLOUR};
+      background-color: ${GREY_4};
+      
+      & > h3 {
+        color: ${LINK_HOVER_COLOUR};
+      }
+    }
+  `}
+`
+StyledEntity.displayName = 'StyledEntity'
+
+const StyledHeading = styled(H3)`
+  margin: 0;
+  color: ${LINK_COLOUR};
+  font-size: ${FONT_SIZE.SIZE_16};
+  ${MEDIA_QUERIES.TABLET} {
+    font-size: ${FONT_SIZE.SIZE_19};
+  }
+`
+
+const StyledInsetText = styled(InsetText)`
+  & {
+    margin-top: ${SPACING.SCALE_2};
+  }
+`
+
+const EntityListItem = ({ canHandleClick, onEntityClick, data, text, heading, meta }) => {
+  return (
+    <StyledEntity
+      key={uniqueId()}
+      onClick={() => (canHandleClick ? onEntityClick(data) : null)}
+      canHandleClick={canHandleClick}
+    >
+      <StyledHeading>{heading}</StyledHeading>
+
+      <EntityListItemMetaList meta={meta} />
+
+      {text && <StyledInsetText>{text}</StyledInsetText>}
+    </StyledEntity>
+  )
+}
+
+EntityListItem.propTypes = {
+  onEntityClick: PropTypes.func.isRequired,
+  data: PropTypes.object.isRequired,
+  canHandleClick: PropTypes.bool.isRequired,
+  text: PropTypes.node,
+  heading: PropTypes.string.isRequired,
+  meta: PropTypes.object.isRequired,
+}
+
+EntityListItem.defaultProps = {
+  text: null,
+}
+
+export default EntityListItem

--- a/src/entity-search/EntityListItemMetaList.jsx
+++ b/src/entity-search/EntityListItemMetaList.jsx
@@ -1,0 +1,34 @@
+import { uniqueId } from 'lodash'
+import React from 'react'
+import styled from 'styled-components'
+import { FONT_SIZE, SPACING } from '@govuk-react/constants'
+import { SECONDARY_TEXT_COLOUR } from 'govuk-colours'
+import PropTypes from 'prop-types'
+
+const StyledMetaItem = styled('div')`
+  list-style-type: none;
+  margin-top: ${SPACING.SCALE_2};
+  font-size: ${FONT_SIZE.SIZE_16};
+    
+  & > span:nth-child(1) {
+    color: ${SECONDARY_TEXT_COLOUR};
+    margin-right: ${SPACING.SCALE_1};
+  }
+`
+
+const EntityListItemMetaList = ({ meta }) => {
+  return (
+    Object.keys(meta).map(metaKey => (
+      <StyledMetaItem key={uniqueId()}>
+        <span>{metaKey}:</span>
+        <span>{meta[metaKey]}</span>
+      </StyledMetaItem>
+    ))
+  )
+}
+
+EntityListItemMetaList.propTypes = {
+  meta: PropTypes.object.isRequired,
+}
+
+export default EntityListItemMetaList

--- a/src/entity-search/EntitySearch.stories.jsx
+++ b/src/entity-search/EntitySearch.stories.jsx
@@ -56,7 +56,11 @@ const EntitySearchForStorybook = ({ previouslySelected, cannotFindLink }) => {
               ],
               link: cannotFindLink,
             }}
-            onEntityClick={entity => alert(`Selected ${JSON.stringify(entity)}`)}
+            onEntityClick={(entity) => {
+              if (!entity.datahub_company) {
+                alert(`Selected ${JSON.stringify(entity)}`)
+              }
+            }}
           />
         </GridCol>
       </GridRow>

--- a/src/entity-search/EntitySearch.test.jsx
+++ b/src/entity-search/EntitySearch.test.jsx
@@ -203,11 +203,11 @@ describe('EntitySearch', () => {
     })
   })
 
-  describe('when the first entity search result is clicked', () => {
+  describe('when the entity search results are clicked', () => {
     let wrappedEntitySearch
     let onEntityClick
 
-    beforeAll(async () => {
+    beforeEach(async () => {
       onEntityClick = jest.fn()
 
       wrappedEntitySearch = wrapEntitySearch({
@@ -219,24 +219,32 @@ describe('EntitySearch', () => {
       await act(flushPromises)
 
       wrappedEntitySearch.update()
-
-      wrappedEntitySearch
-        .find('StyledEntity')
-        .at(0)
-        .simulate('click')
     })
 
     test('should render the component', async () => {
       expect(wrappedEntitySearch.debug()).toMatchSnapshot()
     })
 
-    test('should call the onEntityClick event', async () => {
-      expect(onEntityClick.mock.calls.length).toEqual(1)
-      expect(onEntityClick.mock.calls[0][0]).toEqual({
-        heading: 'Some company name',
-        meta: {
-          Address: '123 Fake Street, Brighton, BN1 4SE',
-        },
+    describe('when the first entity is clicked', () => {
+      test('should not call the onEntityClick event', async () => {
+        wrappedEntitySearch
+          .find('StyledEntity')
+          .at(0)
+          .simulate('click')
+
+        expect(onEntityClick.mock.calls.length).toEqual(0)
+      })
+    })
+
+    describe('when the second entity is clicked', () => {
+      test('should call the onEntityClick event', async () => {
+        wrappedEntitySearch
+          .find('StyledEntity')
+          .at(1)
+          .simulate('click')
+
+        expect(onEntityClick.mock.calls.length).toEqual(1)
+        expect(onEntityClick.mock.calls[0][0]).toEqual(fixtures.companySearch.results[1])
       })
     })
   })

--- a/src/entity-search/__snapshots__/EntitySearch.test.jsx.snap
+++ b/src/entity-search/__snapshots__/EntitySearch.test.jsx.snap
@@ -242,95 +242,103 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
     <EntityList entities={{...}} onEntityClick={[Function]}>
       <styled.ol>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <ol className=\\"sc-exAgwC jYyWiV\\">
+          <ol className=\\"sc-bXGyLb haBriy\\">
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some company name
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 Fake Street, Brighton, BN1 4SE
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                        <Styled(styled.div)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
-                              This company is already on Data Hub. 
-                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
-                                Go to the company page
-                              </a>
-                                to record activity.
-                            </div>
-                          </StyledComponent>
-                        </Styled(styled.div)>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function]} heading=\\"Some company name\\" meta={{...}} text={{...}} canHandleClick={false} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn eADRNi\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some company name
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 Fake Street, Brighton, BN1 4SE
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                          <Styled(styled.div)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <div className=\\"sc-fAjcbJ sc-daURTG bmxPEc\\">
+                                This company is already on Data Hub. 
+                                <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                  Go to the company page
+                                </a>
+                                  to record activity.
+                              </div>
+                            </StyledComponent>
+                          </Styled(styled.div)>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some other company
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 ABC Road, Brighton, BN2 9QB
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function]} heading=\\"Some other company\\" meta={{...}} text={{...}} canHandleClick={true} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn iOmJns\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some other company
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 ABC Road, Brighton, BN2 9QB
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
@@ -798,44 +806,48 @@ exports[`EntitySearch when the company name filter is applied should render the 
     <EntityList entities={{...}} onEntityClick={[Function]}>
       <styled.ol>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <ol className=\\"sc-exAgwC jYyWiV\\">
+          <ol className=\\"sc-bXGyLb haBriy\\">
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some other company
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 ABC Road, Brighton, BN2 9QB
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function]} heading=\\"Some other company\\" meta={{...}} text={{...}} canHandleClick={true} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn iOmJns\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some other company
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 ABC Road, Brighton, BN2 9QB
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
@@ -1041,55 +1053,59 @@ exports[`EntitySearch when the company postcode filter is applied should render 
     <EntityList entities={{...}} onEntityClick={[Function]}>
       <styled.ol>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <ol className=\\"sc-exAgwC jYyWiV\\">
+          <ol className=\\"sc-bXGyLb haBriy\\">
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some company name
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 Fake Street, Brighton, BN1 4SE
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                        <Styled(styled.div)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
-                              This company is already on Data Hub. 
-                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
-                                Go to the company page
-                              </a>
-                                to record activity.
-                            </div>
-                          </StyledComponent>
-                        </Styled(styled.div)>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function]} heading=\\"Some company name\\" meta={{...}} text={{...}} canHandleClick={false} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn eADRNi\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some company name
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 Fake Street, Brighton, BN1 4SE
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                          <Styled(styled.div)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <div className=\\"sc-fAjcbJ sc-daURTG bmxPEc\\">
+                                This company is already on Data Hub. 
+                                <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                  Go to the company page
+                                </a>
+                                  to record activity.
+                              </div>
+                            </StyledComponent>
+                          </Styled(styled.div)>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
@@ -1295,95 +1311,103 @@ exports[`EntitySearch when the entity search results are clicked should render t
     <EntityList entities={{...}} onEntityClick={[Function: mockConstructor]}>
       <styled.ol>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <ol className=\\"sc-exAgwC jYyWiV\\">
+          <ol className=\\"sc-bXGyLb haBriy\\">
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some company name
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 Fake Street, Brighton, BN1 4SE
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                        <Styled(styled.div)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
-                              This company is already on Data Hub. 
-                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
-                                Go to the company page
-                              </a>
-                                to record activity.
-                            </div>
-                          </StyledComponent>
-                        </Styled(styled.div)>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function: mockConstructor]} heading=\\"Some company name\\" meta={{...}} text={{...}} canHandleClick={false} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn eADRNi\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some company name
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 Fake Street, Brighton, BN1 4SE
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                          <Styled(styled.div)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <div className=\\"sc-fAjcbJ sc-daURTG bmxPEc\\">
+                                This company is already on Data Hub. 
+                                <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                  Go to the company page
+                                </a>
+                                  to record activity.
+                              </div>
+                            </StyledComponent>
+                          </Styled(styled.div)>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some other company
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 ABC Road, Brighton, BN2 9QB
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function: mockConstructor]} heading=\\"Some other company\\" meta={{...}} text={{...}} canHandleClick={true} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn iOmJns\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some other company
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 ABC Road, Brighton, BN2 9QB
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
@@ -1589,95 +1613,103 @@ exports[`EntitySearch when the the cannot find link has a callback should render
     <EntityList entities={{...}} onEntityClick={[Function]}>
       <styled.ol>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <ol className=\\"sc-exAgwC jYyWiV\\">
+          <ol className=\\"sc-bXGyLb haBriy\\">
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some company name
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 Fake Street, Brighton, BN1 4SE
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                        <Styled(styled.div)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
-                              This company is already on Data Hub. 
-                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
-                                Go to the company page
-                              </a>
-                                to record activity.
-                            </div>
-                          </StyledComponent>
-                        </Styled(styled.div)>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function]} heading=\\"Some company name\\" meta={{...}} text={{...}} canHandleClick={false} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn eADRNi\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some company name
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 Fake Street, Brighton, BN1 4SE
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                          <Styled(styled.div)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <div className=\\"sc-fAjcbJ sc-daURTG bmxPEc\\">
+                                This company is already on Data Hub. 
+                                <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                  Go to the company page
+                                </a>
+                                  to record activity.
+                              </div>
+                            </StyledComponent>
+                          </Styled(styled.div)>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some other company
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 ABC Road, Brighton, BN2 9QB
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function]} heading=\\"Some other company\\" meta={{...}} text={{...}} canHandleClick={true} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn iOmJns\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some other company
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 ABC Road, Brighton, BN2 9QB
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
@@ -1895,95 +1927,103 @@ exports[`EntitySearch when there is a previously selected "Change" link which is
     <EntityList entities={{...}} onEntityClick={[Function]}>
       <styled.ol>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <ol className=\\"sc-exAgwC jYyWiV\\">
+          <ol className=\\"sc-bXGyLb haBriy\\">
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some company name
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 Fake Street, Brighton, BN1 4SE
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                        <Styled(styled.div)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
-                              This company is already on Data Hub. 
-                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
-                                Go to the company page
-                              </a>
-                                to record activity.
-                            </div>
-                          </StyledComponent>
-                        </Styled(styled.div)>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function]} heading=\\"Some company name\\" meta={{...}} text={{...}} canHandleClick={false} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn eADRNi\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some company name
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 Fake Street, Brighton, BN1 4SE
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                          <Styled(styled.div)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <div className=\\"sc-fAjcbJ sc-daURTG bmxPEc\\">
+                                This company is already on Data Hub. 
+                                <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                  Go to the company page
+                                </a>
+                                  to record activity.
+                              </div>
+                            </StyledComponent>
+                          </Styled(styled.div)>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
-                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
-                        <Styled(H3)>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <H3 className=\\"sc-daURTG jaGlRd\\">
-                              <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" level={[undefined]}>
-                                <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\">
-                                  <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                                    <h3 size=\\"MEDIUM\\" className=\\"sc-daURTG jaGlRd sc-cMljjf kCLKvB\\">
-                                      Some other company
-                                    </h3>
-                                  </StyledComponent>
-                                </styled.h1>
-                              </Heading>
-                            </H3>
-                          </StyledComponent>
-                        </Styled(H3)>
-                        <styled.div>
-                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                            <div className=\\"sc-bXGyLb boBdwp\\">
-                              <span>
-                                Address
-                                :
-                              </span>
-                              <span>
-                                123 ABC Road, Brighton, BN2 9QB
-                              </span>
-                            </div>
-                          </StyledComponent>
-                        </styled.div>
-                      </div>
-                    </StyledComponent>
-                  </StyledEntity>
+                <li className=\\"sc-lkqHmb jBjITi\\">
+                  <EntityListItem onEntityClick={[Function]} heading=\\"Some other company\\" meta={{...}} text={{...}} canHandleClick={true} data={{...}}>
+                    <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                      <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div onClick={[Function: onClick]} className=\\"sc-cQFLBn iOmJns\\">
+                          <Styled(H3)>
+                            <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                              <H3 className=\\"sc-gojNiO byNnwj\\">
+                                <Heading as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" level={[undefined]}>
+                                  <styled.h1 as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\">
+                                    <StyledComponent as=\\"h3\\" size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                                      <h3 size=\\"MEDIUM\\" className=\\"sc-gojNiO byNnwj sc-cMljjf kCLKvB\\">
+                                        Some other company
+                                      </h3>
+                                    </StyledComponent>
+                                  </styled.h1>
+                                </Heading>
+                              </H3>
+                            </StyledComponent>
+                          </Styled(H3)>
+                          <EntityListItemMetaList meta={{...}}>
+                            <styled.div>
+                              <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                                <div className=\\"sc-exAgwC jaSAbg\\">
+                                  <span>
+                                    Address
+                                    :
+                                  </span>
+                                  <span>
+                                    123 ABC Road, Brighton, BN2 9QB
+                                  </span>
+                                </div>
+                              </StyledComponent>
+                            </styled.div>
+                          </EntityListItemMetaList>
+                        </div>
+                      </StyledComponent>
+                    </StyledEntity>
+                  </EntityListItem>
                 </li>
               </StyledComponent>
             </styled.li>

--- a/src/entity-search/__snapshots__/EntitySearch.test.jsx.snap
+++ b/src/entity-search/__snapshots__/EntitySearch.test.jsx.snap
@@ -6,14 +6,14 @@ exports[`EntitySearch when initially loading the entity search component should 
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -60,10 +60,10 @@ exports[`EntitySearch when initially loading the entity search component should 
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -113,10 +113,10 @@ exports[`EntitySearch when initially loading the entity search component should 
     </EntityFilters>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>
@@ -134,14 +134,14 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -188,10 +188,10 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -246,9 +246,9 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -277,6 +277,17 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
                             </div>
                           </StyledComponent>
                         </styled.div>
+                        <Styled(styled.div)>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
+                              This company is already on Data Hub. 
+                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                Go to the company page
+                              </a>
+                                to record activity.
+                            </div>
+                          </StyledComponent>
+                        </Styled(styled.div)>
                       </div>
                     </StyledComponent>
                   </StyledEntity>
@@ -286,9 +297,9 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -396,10 +407,10 @@ exports[`EntitySearch when the "Search" button has been clicked should render th
     </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>
@@ -417,14 +428,14 @@ exports[`EntitySearch when the API returns 0 results should render the component
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -471,10 +482,10 @@ exports[`EntitySearch when the API returns 0 results should render the component
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -527,10 +538,10 @@ exports[`EntitySearch when the API returns 0 results should render the component
     </p>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>
@@ -548,14 +559,14 @@ exports[`EntitySearch when the API returns a server error should render the comp
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -602,10 +613,10 @@ exports[`EntitySearch when the API returns a server error should render the comp
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -658,10 +669,10 @@ exports[`EntitySearch when the API returns a server error should render the comp
     </p>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>
@@ -679,14 +690,14 @@ exports[`EntitySearch when the company name filter is applied should render the 
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -733,10 +744,10 @@ exports[`EntitySearch when the company name filter is applied should render the 
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -791,9 +802,9 @@ exports[`EntitySearch when the company name filter is applied should render the 
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -901,10 +912,10 @@ exports[`EntitySearch when the company name filter is applied should render the 
     </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>
@@ -922,14 +933,14 @@ exports[`EntitySearch when the company postcode filter is applied should render 
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -976,10 +987,10 @@ exports[`EntitySearch when the company postcode filter is applied should render 
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -1034,9 +1045,9 @@ exports[`EntitySearch when the company postcode filter is applied should render 
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -1065,6 +1076,17 @@ exports[`EntitySearch when the company postcode filter is applied should render 
                             </div>
                           </StyledComponent>
                         </styled.div>
+                        <Styled(styled.div)>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
+                              This company is already on Data Hub. 
+                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                Go to the company page
+                              </a>
+                                to record activity.
+                            </div>
+                          </StyledComponent>
+                        </Styled(styled.div)>
                       </div>
                     </StyledComponent>
                   </StyledEntity>
@@ -1144,10 +1166,10 @@ exports[`EntitySearch when the company postcode filter is applied should render 
     </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>
@@ -1159,20 +1181,20 @@ exports[`EntitySearch when the company postcode filter is applied should render 
 </EntitySearchWithDataProvider>"
 `;
 
-exports[`EntitySearch when the first entity search result is clicked should render the component 1`] = `
+exports[`EntitySearch when the entity search results are clicked should render the component 1`] = `
 "<EntitySearchWithDataProvider previouslySelected={[undefined]} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}} onEntityClick={[Function: mockConstructor]}>
   <EntitySearch entities={{...}} error={{...}} onEntitySearch={[Function: onEntitySearch]} previouslySelected={{...}} getEntities={[Function]} entityFilters={{...}} cannotFind={{...}} onEntityClick={[Function: mockConstructor]}>
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -1219,10 +1241,10 @@ exports[`EntitySearch when the first entity search result is clicked should rend
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -1277,9 +1299,9 @@ exports[`EntitySearch when the first entity search result is clicked should rend
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -1308,6 +1330,17 @@ exports[`EntitySearch when the first entity search result is clicked should rend
                             </div>
                           </StyledComponent>
                         </styled.div>
+                        <Styled(styled.div)>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
+                              This company is already on Data Hub. 
+                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                Go to the company page
+                              </a>
+                                to record activity.
+                            </div>
+                          </StyledComponent>
+                        </Styled(styled.div)>
                       </div>
                     </StyledComponent>
                   </StyledEntity>
@@ -1317,9 +1350,9 @@ exports[`EntitySearch when the first entity search result is clicked should rend
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -1427,10 +1460,10 @@ exports[`EntitySearch when the first entity search result is clicked should rend
     </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>
@@ -1448,14 +1481,14 @@ exports[`EntitySearch when the the cannot find link has a callback should render
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -1502,10 +1535,10 @@ exports[`EntitySearch when the the cannot find link has a callback should render
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -1560,9 +1593,9 @@ exports[`EntitySearch when the the cannot find link has a callback should render
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -1591,6 +1624,17 @@ exports[`EntitySearch when the the cannot find link has a callback should render
                             </div>
                           </StyledComponent>
                         </styled.div>
+                        <Styled(styled.div)>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
+                              This company is already on Data Hub. 
+                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                Go to the company page
+                              </a>
+                                to record activity.
+                            </div>
+                          </StyledComponent>
+                        </Styled(styled.div)>
                       </div>
                     </StyledComponent>
                   </StyledEntity>
@@ -1600,9 +1644,9 @@ exports[`EntitySearch when the the cannot find link has a callback should render
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -1710,10 +1754,10 @@ exports[`EntitySearch when the the cannot find link has a callback should render
     </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>
@@ -1733,7 +1777,7 @@ exports[`EntitySearch when there is a previously selected "Change" link which is
         previously selected
         <Styled(styled.a) href=\\"#previously-selected\\" onClick={[Function: onClick]} muted={false} textColour={false} noVisitedState={false}>
           <StyledComponent href=\\"#previously-selected\\" onClick={[Function: onClick]} muted={false} textColour={false} noVisitedState={false} forwardedComponent={{...}} forwardedRef={{...}}>
-            <a href=\\"#previously-selected\\" onClick={[Function: onClick]} muted={false} className=\\"sc-cHGsZl sc-cbkKFq izPlg\\">
+            <a href=\\"#previously-selected\\" onClick={[Function: onClick]} muted={false} className=\\"sc-cHGsZl sc-krvtoX dxfRYO\\">
               Change
             </a>
           </StyledComponent>
@@ -1743,14 +1787,14 @@ exports[`EntitySearch when there is a previously selected "Change" link which is
     <EntityFilters entityFilters={{...}} setFilter={[Function: setFilter]}>
       <styled.div>
         <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-          <div className=\\"sc-eLExRp jnbiWj\\">
+          <div className=\\"sc-cbkKFq dyUdlj\\">
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth={[undefined]} columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -1797,10 +1841,10 @@ exports[`EntitySearch when there is a previously selected "Change" link which is
             <EntityFilterRow filterRow={{...}} setFilter={[Function: setFilter]}>
               <Styled(GridRow)>
                 <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
-                  <GridRow className=\\"sc-lkqHmb lpinkg\\">
-                    <styled.div className=\\"sc-lkqHmb lpinkg\\">
-                      <StyledComponent className=\\"sc-lkqHmb lpinkg\\" forwardedComponent={{...}} forwardedRef={{...}}>
-                        <div className=\\"sc-lkqHmb lpinkg sc-fMiknA gIEufr\\">
+                  <GridRow className=\\"sc-eLExRp igxVGH\\">
+                    <styled.div className=\\"sc-eLExRp igxVGH\\">
+                      <StyledComponent className=\\"sc-eLExRp igxVGH\\" forwardedComponent={{...}} forwardedRef={{...}}>
+                        <div className=\\"sc-eLExRp igxVGH sc-fMiknA gIEufr\\">
                           <GridCol setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                             <styled.div setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]}>
                               <StyledComponent setWidth=\\"one-half\\" columnOneQuarter={false} columnOneThird={false} columnOneHalf={false} columnTwoThirds={false} columnThreeQuarters={false} columnFull={false} setDesktopWidth={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
@@ -1855,9 +1899,9 @@ exports[`EntitySearch when there is a previously selected "Change" link which is
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={false}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={false} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO igJVfx\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -1886,6 +1930,17 @@ exports[`EntitySearch when there is a previously selected "Change" link which is
                             </div>
                           </StyledComponent>
                         </styled.div>
+                        <Styled(styled.div)>
+                          <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
+                            <div className=\\"sc-fAjcbJ sc-lkqHmb cDHXRT\\">
+                              This company is already on Data Hub. 
+                              <a href=\\"/companies/0fb3379c-341c-4da4-b825-bf8d47b26baa\\">
+                                Go to the company page
+                              </a>
+                                to record activity.
+                            </div>
+                          </StyledComponent>
+                        </Styled(styled.div)>
                       </div>
                     </StyledComponent>
                   </StyledEntity>
@@ -1895,9 +1950,9 @@ exports[`EntitySearch when there is a previously selected "Change" link which is
             <styled.li>
               <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                 <li className=\\"sc-cQFLBn erMDhO\\">
-                  <StyledEntity onClick={[Function: onClick]}>
-                    <StyledComponent onClick={[Function: onClick]} forwardedComponent={{...}} forwardedRef={{...}}>
-                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO dFyMgk\\">
+                  <StyledEntity onClick={[Function: onClick]} canHandleClick={true}>
+                    <StyledComponent onClick={[Function: onClick]} canHandleClick={true} forwardedComponent={{...}} forwardedRef={{...}}>
+                      <div onClick={[Function: onClick]} className=\\"sc-gojNiO cSygrj\\">
                         <Styled(H3)>
                           <StyledComponent forwardedComponent={{...}} forwardedRef={{...}}>
                             <H3 className=\\"sc-daURTG jaGlRd\\">
@@ -2005,10 +2060,10 @@ exports[`EntitySearch when there is a previously selected "Change" link which is
     </CannotFindDetails>
     <Search onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]}>
       <StyledComponent onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} forwardedComponent={{...}} forwardedRef={{...}}>
-        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\">
-            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-krvtoX hrEdhT\\" forwardedComponent={{...}} forwardedRef={{...}}>
-              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-krvtoX hrEdhT sc-VigVT krXvSZ\\">
+        <ForwardRef onClick={[Function: onClick]} icon={[undefined]} disabled={false} start={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+          <styled.button isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\">
+            <StyledComponent isStart={false} icon={[undefined]} onClick={[Function: onClick]} disabled={false} buttonColour={[undefined]} buttonHoverColour={[undefined]} buttonShadowColour={[undefined]} buttonTextColour={[undefined]} className=\\"sc-fYiAbW bAGbIC\\" forwardedComponent={{...}} forwardedRef={{...}}>
+              <button onClick={[Function: onClick]} disabled={false} className=\\"sc-fYiAbW bAGbIC sc-VigVT krXvSZ\\">
                 Search
               </button>
             </StyledComponent>

--- a/src/entity-search/data-providers/DnbCompanySearch.jsx
+++ b/src/entity-search/data-providers/DnbCompanySearch.jsx
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+import React from 'react'
 import axios from 'axios'
 import { compact, join } from 'lodash'
 import queryString from 'query-string'
@@ -7,8 +9,9 @@ export default (apiEndpoint) => {
     const transformed = queryString.stringify(filters)
     const { data } = await axios.post(`${apiEndpoint + (transformed ? `?${transformed}` : '')}`)
 
-    // eslint-disable-next-line camelcase
-    return data.results.map(({ dnb_company }) => {
+    return data.results.map((result) => {
+      const { dnb_company, datahub_company } = result
+
       return {
         heading: dnb_company.primary_name,
         meta: {
@@ -20,6 +23,15 @@ export default (apiEndpoint) => {
             dnb_company.address_postcode,
           ]), ', '),
         },
+        text: datahub_company ? (
+          <>
+            This company is already on Data Hub.&nbsp;
+            <a href={`/companies/${datahub_company.id}`}>Go to the company page</a>&nbsp;
+            to record activity.
+          </>
+        ) : null,
+        canHandleClick: !datahub_company,
+        data: result,
       }
     })
   }


### PR DESCRIPTION
## Description of change
For some entities we may want to display some inset text and therefore handle click events in a different way.

An example of this is for companies that are known by DIT. We will display a message containing a link so that the user can browse to the company page and add activity. In this case the entity click event should be ignored. When the company is not known by DIT then the entity click event is handled to move to the next stage of the process for adding a company.

## Test instructions
1. Browse to `/?path=/story/entitysearch--data-hub-company-search`
2. Click the first entity and the click event is ignored. Click the `Go to the company page` link the URL will change
3. Click the second entity and the click event is handled with an `alert`

## Screenshots
### Before
<img width="901" alt="Screenshot 2019-08-22 at 14 59 48" src="https://user-images.githubusercontent.com/1150417/63521056-a53c5a80-c4ed-11e9-8728-f9ef81b9026a.png">

### After
<img width="918" alt="Screenshot 2019-08-22 at 14 59 07" src="https://user-images.githubusercontent.com/1150417/63521068-aa99a500-c4ed-11e9-894a-c39fe9ef57fe.png">
