### PR TITLE
feat: Support multiple validators in forms field

### DIFF
--- a/src/forms/core/__tests__/useForm.test.jsx
+++ b/src/forms/core/__tests__/useForm.test.jsx
@@ -3,25 +3,67 @@ import { renderHook, act } from '@testing-library/react-hooks'
 import useForm from '../useForm'
 
 const validate = value => (value !== 'correctValue' ? 'testError1' : null)
-const testFields = [
-  {
-    name: 'testField1',
-    label: 'testLabel1',
-    initialValue: 'testInitialValue1',
-    validate,
-  },
-  {
-    name: 'testField2',
-    label: 'testLabel2',
-  },
-]
+const testField1 = {
+  name: 'testField1',
+  label: 'testLabel1',
+  initialValue: 'testInitialValue1',
+  validate,
+}
+const testField2 = {
+  name: 'testField2',
+  label: 'testLabel2',
+}
 
 describe('useForm', () => {
+  describe('when getFieldState() is called', () => {
+    let fieldState
+
+    beforeAll(async () => {
+      const { result } = renderHook(() => useForm())
+
+      await act(async () => {
+        result.current.registerField(testField1)
+
+        // Wait for field to register.
+        await Promise.resolve()
+
+        fieldState = result.current.getFieldState('testField1')
+      })
+    })
+
+    test('should return field state', () => {
+      expect(fieldState).toEqual({
+        error: null,
+        touched: false,
+        value: 'testInitialValue1',
+      })
+    })
+  })
+
+  describe('when getFieldState() is called on nonexistent field', () => {
+    const { result } = renderHook(() => useForm())
+    const fieldState = result.current.getFieldState('testField1')
+
+    test('should return an object with default values', () => {
+      expect(fieldState).toEqual({
+        error: null,
+        touched: false,
+        value: '',
+      })
+    })
+  })
+
   describe('when registerField() is called', () => {
     const { result } = renderHook(() => useForm())
 
-    act(() => {
-      testFields.map(result.current.registerField)
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerField(testField1)
+        result.current.registerField(testField2)
+
+        // Wait for fields to register.
+        await Promise.resolve()
+      })
     })
 
     test('should register fields', () => {
@@ -54,15 +96,19 @@ describe('useForm', () => {
   describe('when deregisterField() is called', () => {
     const { result } = renderHook(() => useForm())
 
-    act(() => {
-      testFields.map(result.current.deregisterField)
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerField(testField1)
+
+        // Wait for field to register.
+        await Promise.resolve()
+
+        result.current.deregisterField('testField1')
+      })
     })
 
     test('should deregister field', () => {
       expect(result.current.fields).toEqual({})
-    })
-    test('should remove field value', () => {
-      expect(result.current.values).toEqual({})
     })
     test('should unmark field as touched', () => {
       expect(result.current.touched).toEqual({})
@@ -75,9 +121,14 @@ describe('useForm', () => {
   describe('when registerField() is called on already registered field', () => {
     const { result } = renderHook(() => useForm())
 
-    act(() => {
-      result.current.registerField(testFields[0])
-      result.current.registerField(testFields[0])
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerField(testField1)
+        result.current.registerField(testField1)
+
+        // Wait for fields to register.
+        await Promise.resolve()
+      })
     })
 
     test('should not register a duplicated field', () => {
@@ -88,9 +139,14 @@ describe('useForm', () => {
   describe('when registerStep() is called on already registered step', () => {
     const { result } = renderHook(() => useForm())
 
-    act(() => {
-      result.current.registerStep('testStep1')
-      result.current.registerStep('testStep1')
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerStep('testStep1')
+        result.current.registerStep('testStep1')
+
+        // Wait for steps to register.
+        await Promise.resolve()
+      })
     })
 
     test('should not register a duplicated step', () => {
@@ -150,15 +206,10 @@ describe('useForm', () => {
 
   describe('when validateForm() is called on nonexistent field', () => {
     const { result } = renderHook(() => useForm())
+    const callback = () => result.current.validateForm(['madeUpField'])
 
-    act(() => {
-      result.current.validateForm(['madeUpField'])
-    })
-
-    test('should return an error', () => {
-      expect(result.current.errors).toEqual({
-        madeUpField: 'Field does not exists',
-      })
+    test('should throw an exception', () => {
+      expect(callback).toThrowError('Field madeUpField does not exist')
     })
   })
 
@@ -166,11 +217,11 @@ describe('useForm', () => {
     const { result } = renderHook(() => useForm())
 
     act(() => {
-      result.current.registerField(testFields[0])
+      result.current.registerField(testField1)
       result.current.deregisterField(['testField1'])
     })
 
-    test('should return an error', () => {
+    test('should remove fields from the form state', () => {
       expect(result.current.fields).toEqual({})
     })
 
@@ -182,12 +233,140 @@ describe('useForm', () => {
   describe('when registerStep() is called', () => {
     const { result } = renderHook(() => useForm())
 
-    act(() => {
-      result.current.registerStep('testStep')
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerStep('testStep')
+
+        // Wait for step to register.
+        await Promise.resolve()
+      })
     })
 
     test('should add the step to form state', () => {
       expect(result.current.steps).toEqual(['testStep'])
+    })
+  })
+
+  describe('when validateField() is called with a single validator', () => {
+    const { result } = renderHook(() => useForm())
+    let error = null
+
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerField({
+          name: 'testField1',
+          validate: () => 'testError1',
+        })
+
+        // Wait for field to register.
+        await Promise.resolve()
+
+        error = result.current.validateField('testField1')
+      })
+    })
+
+    test('should return an error', () => {
+      expect(error).toEqual('testError1')
+    })
+  })
+
+  describe('when validateField() is called with multiple validators and both fails validation', () => {
+    const { result } = renderHook(() => useForm())
+    let error
+
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerField({
+          name: 'testField1',
+          validate: [
+            () => 'testError1',
+            () => 'testError2',
+          ],
+        })
+
+        // Wait for field to register.
+        await Promise.resolve()
+
+        error = result.current.validateField('testField1')
+      })
+    })
+
+    test('should return an error only from the first validator', () => {
+      expect(error).toEqual('testError1')
+    })
+  })
+
+  describe('when validateField() is called with multiple validators and only one fails validation', () => {
+    const { result } = renderHook(() => useForm())
+    let error
+
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerField({
+          name: 'testField1',
+          validate: [
+            () => null,
+            () => 'testError2',
+          ],
+        })
+
+        // Wait for field to register.
+        await Promise.resolve()
+
+        error = result.current.validateField('testField1')
+      })
+    })
+
+    test('should return an error from the second validator', () => {
+      expect(error).toEqual('testError2')
+    })
+  })
+
+  describe('when validateField() is called with multiple validators and none fails validation', () => {
+    const { result } = renderHook(() => useForm())
+    let error
+
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerField({
+          name: 'testField1',
+          validate: [
+            () => null,
+            () => null,
+          ],
+        })
+
+        // Wait for field to register.
+        await Promise.resolve()
+
+        error = result.current.validateField('testField1')
+      })
+    })
+
+    test('should return null', () => {
+      expect(error).toEqual(null)
+    })
+  })
+
+  describe('when validateField() is called on a field without validation', () => {
+    const { result } = renderHook(() => useForm())
+    let error = null
+
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerField({
+          name: 'testField1',
+        })
+
+        // Wait for field to register.
+        await Promise.resolve()
+
+        error = result.current.validateField('testField1')
+      })
+    })
+
+    test('should return null', () => {
+      expect(error).toBeNull()
     })
   })
 
@@ -201,6 +380,27 @@ describe('useForm', () => {
 
     test('should remove the step from the form state', () => {
       expect(result.current.steps).toEqual([])
+    })
+  })
+
+  describe('when goToStepByName() is called', () => {
+    const { result } = renderHook(() => useForm())
+
+    beforeAll(async () => {
+      await act(async () => {
+        result.current.registerStep('testStep1')
+        result.current.registerStep('testStep2')
+        result.current.registerStep('testStep3')
+
+        // Wait for steps to register.
+        await Promise.resolve()
+
+        result.current.goToStepByName('testStep3')
+      })
+    })
+
+    test('should update the current step', () => {
+      expect(result.current.currentStep).toEqual(2)
     })
   })
 })

--- a/src/forms/elements/__tests__/FieldError.test.jsx
+++ b/src/forms/elements/__tests__/FieldError.test.jsx
@@ -17,7 +17,7 @@ describe('FieldError', () => {
       )
     })
 
-    test('should render with the error', () => {
+    test('should render without an error', () => {
       expect(wrapper.find(FieldError).text()).toEqual('')
     })
   })
@@ -26,15 +26,14 @@ describe('FieldError', () => {
     beforeAll(() => {
       wrapper = mount(
         <Form>
-          <FieldError name="testField" />
           <FieldInput type="text" name="testField" validate={() => 'testError'} />
         </Form>,
       )
       wrapper.find('form').simulate('submit')
     })
 
-    test('should render with the error', () => {
-      expect(wrapper.find(FieldError).at(0).text()).toEqual('testError')
+    test('should render with an error', () => {
+      expect(wrapper.find(FieldError).text()).toEqual('testError')
     })
   })
 })


### PR DESCRIPTION
Let users define more than one validator in fields.

Before:
```
<FieldInput
  type="text"
  name="name"
  label="Name"
  validate={value => (!value ? 'name is required' : null)}
/>
```

After:
```
<FieldInput
  type="text"
  name="name"
  label="Name"
  validate=[
    validateRequired,
    validateName,
  ]
/>
```