### PR TITLE
feat: POST object rather than query params

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "moment": "^2.24.0",
     "pluralise": "^1.0.1",
     "prop-types": "^15.7.2",
-    "query-string": "^6.8.2",
     "react-lines-ellipsis": "^0.14.1",
     "react-markdown": "^4.0.8",
     "styled-components": "^4.2.0"

--- a/src/entity-search/EntitySearch.stories.jsx
+++ b/src/entity-search/EntitySearch.stories.jsx
@@ -13,16 +13,35 @@ import EntitySearchWithDataProvider from './EntitySearchWithDataProvider'
 
 const mock = new MockAdapter(axios)
 const apiEndpoint = 'http://localhost:3010/v4/dnb/company-search'
-const apiEndpointWithParameters = new RegExp(`${apiEndpoint}.+`)
 
-const setupSuccessMocks = (response = fixtures.companySearch) => {
-  mock.onPost(apiEndpoint).reply(200, response)
-  mock.onPost(apiEndpointWithParameters).reply(200, response)
+const setupSuccessMocks = () => {
+  mock
+    .onPost(apiEndpoint, {})
+    .reply(200, fixtures.companySearch)
+  mock
+    .onPost(apiEndpoint, { search_term: 'some other company' })
+    .reply(200, fixtures.companySearchFilteredByCompanyName)
+  mock
+    .onPost(apiEndpoint, { address_postcode: 'BN1 4SE' })
+    .reply(200, fixtures.companySearchFilteredByPostcode)
 }
 
 const setupErrorMocks = () => {
-  mock.onPost(apiEndpoint).reply(500)
-  mock.onPost(apiEndpointWithParameters).reply(500)
+  mock.onPost(apiEndpoint, {}).reply(500)
+  mock.onPost(apiEndpoint, { search_term: 'some other company' }).reply(500)
+  mock.onPost(apiEndpoint, { address_postcode: 'BN1 4SE' }).reply(500)
+}
+
+const setupNoResultsMocks = () => {
+  mock
+    .onPost(apiEndpoint, {})
+    .reply(200, fixtures.companySearchNoResults)
+  mock
+    .onPost(apiEndpoint, { search_term: 'some other company' })
+    .reply(200, fixtures.companySearchNoResults)
+  mock
+    .onPost(apiEndpoint, { address_postcode: 'BN1 4SE' })
+    .reply(200, fixtures.companySearchNoResults)
 }
 
 const EntitySearchForStorybook = ({ previouslySelected, cannotFindLink }) => {
@@ -130,7 +149,7 @@ storiesOf('EntitySearch', module)
     )
   })
   .add('Data Hub company search with no results', () => {
-    setupSuccessMocks(fixtures.companySearchNoResults)
+    setupNoResultsMocks()
 
     return (
       <EntitySearchForStorybook />

--- a/src/entity-search/EntitySearch.test.jsx
+++ b/src/entity-search/EntitySearch.test.jsx
@@ -11,13 +11,13 @@ import EntitySearchWithDataProvider from './EntitySearchWithDataProvider'
 const mock = new MockAdapter(axios)
 const API_ENDPOINT = 'http://localhost:8000/v4/dnb/company-search'
 mock
-  .onPost(API_ENDPOINT)
+  .onPost(API_ENDPOINT, {})
   .reply(200, fixtures.companySearch)
 mock
-  .onPost(`${API_ENDPOINT}?search_term=some%20other%20company`)
+  .onPost(API_ENDPOINT, { search_term: 'some other company' })
   .reply(200, fixtures.companySearchFilteredByCompanyName)
 mock
-  .onPost(`${API_ENDPOINT}?address_postcode=BN1%204SE`)
+  .onPost(API_ENDPOINT, { address_postcode: 'BN1 4SE' })
   .reply(200, fixtures.companySearchFilteredByPostcode)
 
 const flushPromises = () => {
@@ -263,7 +263,7 @@ describe('EntitySearch', () => {
 
   describe('when the API returns a server error', () => {
     beforeAll(() => {
-      mock.onPost(API_ENDPOINT).reply(500)
+      mock.onPost(API_ENDPOINT, {}).reply(500)
     })
 
     test('should render the component with an error message', async () => {
@@ -281,7 +281,7 @@ describe('EntitySearch', () => {
 
   describe('when the API returns 0 results', () => {
     beforeAll(() => {
-      mock.onPost(API_ENDPOINT).reply(200, fixtures.companySearchNoResults)
+      mock.onPost(API_ENDPOINT, {}).reply(200, fixtures.companySearchNoResults)
     })
 
     test('should render the component with a "no entities" message', async () => {

--- a/src/entity-search/data-providers/DnbCompanySearch.jsx
+++ b/src/entity-search/data-providers/DnbCompanySearch.jsx
@@ -2,12 +2,10 @@
 import React from 'react'
 import axios from 'axios'
 import { compact, join } from 'lodash'
-import queryString from 'query-string'
 
 export default (apiEndpoint) => {
   return async (filters) => {
-    const transformed = queryString.stringify(filters)
-    const { data } = await axios.post(`${apiEndpoint + (transformed ? `?${transformed}` : '')}`)
+    const { data } = await axios.post(apiEndpoint, filters)
 
     return data.results.map((result) => {
       const { dnb_company, datahub_company } = result

--- a/yarn.lock
+++ b/yarn.lock
@@ -10574,15 +10574,6 @@ query-string@^6.2.0:
     split-on-first "^1.0.0"
     strict-uri-encode "^2.0.0"
 
-query-string@^6.8.2:
-  version "6.8.2"
-  resolved "https://registry.yarnpkg.com/query-string/-/query-string-6.8.2.tgz#36cb7e452ae11a4b5e9efee83375e0954407b2f6"
-  integrity sha512-J3Qi8XZJXh93t2FiKyd/7Ec6GNifsjKXUsVFkSBj/kjLsDylWhnCz4NT1bkPcKotttPW+QbKGqqPH8OoI2pdqw==
-  dependencies:
-    decode-uri-component "^0.2.0"
-    split-on-first "^1.0.0"
-    strict-uri-encode "^2.0.0"
-
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"


### PR DESCRIPTION
## Description of change
Rather than appending a query string, this change will mean that the filters will be in the body of the `POST` request.

The rationale for doing this is that it is uncommon to use the query string to `POST` data to the server and this is normally done by sending it in the body after the headers. This will make the request consistent with what is expected by the existing backend API endpoint. In addition this was becoming difficult to manage as the CSRF token was also being appended to the query string.