### PR TITLE
test: Remove redundant tests in Activity Feed

### DIFF
--- a/src/activity-feed/ActivityFeed.test.jsx
+++ b/src/activity-feed/ActivityFeed.test.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import renderer from 'react-test-renderer'
-import MockDate from 'mockdate'
 import { uniqueId } from 'lodash'
 import { mount } from 'enzyme'
 import { Details } from 'govuk-react'
@@ -8,46 +7,12 @@ import { Details } from 'govuk-react'
 import ActivityFeed from './ActivityFeed'
 import interactionActivityFixture from '../../fixtures/activity_feed/interactions/interaction'
 
-// Lock the date so moment's relative date doesn't break our deterministic tests.
-MockDate.set(1559750582706)
-
-const FEED_MAX_RENDER_TIME_SECONDS = 7.0
 
 const generateActivities = total => Array.from({ length: total }, () => ({
   ...interactionActivityFixture,
   id: uniqueId(),
 }))
 
-class MockedActivityFeed extends React.Component {
-  constructor(props) {
-    super(props)
-    this.state = {
-      activities: [],
-    }
-  }
-
-  onLoadMore = () => {
-    this.setState((prevState) => {
-      const { activities } = prevState
-      const allActivities = activities.concat(generateActivities(10))
-
-      return {
-        activities: allActivities,
-      }
-    })
-  }
-
-  render() {
-    const { activities } = this.state
-    return (
-      <ActivityFeed
-        hasMore={true}
-        onLoadMore={this.onLoadMore}
-        activities={activities}
-      />
-    )
-  }
-}
 
 describe('ActivityFeed', () => {
   describe('when the feed is empty', () => {
@@ -109,25 +74,6 @@ describe('ActivityFeed', () => {
         )
         .toJSON()
       expect(tree).toMatchSnapshot()
-    })
-  })
-
-  describe('when the activity feed has many activities', () => {
-    test(`should render the entire feed under ${FEED_MAX_RENDER_TIME_SECONDS}s`, () => {
-      const timeStart = process.hrtime()
-
-      const wrapper = (
-        <MockedActivityFeed />
-      )
-      const button = mount(wrapper).find('button')
-      for (let i = 0; i < 20; i += 1) {
-        button.simulate('click')
-      }
-
-      const [seconds, nanoseconds] = process.hrtime(timeStart)
-      const totalTimeElapsed = parseFloat(`${seconds}.${nanoseconds}`)
-
-      expect(totalTimeElapsed).toBeLessThanOrEqual(FEED_MAX_RENDER_TIME_SECONDS)
     })
   })
 


### PR DESCRIPTION
This is a performance tests and should be handled separately, 

For instance, `ActivityFeed.perf.js` could make use of the  `benchmark.js` library.