### PR TITLE
Add Field D&B company

### DIFF
--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -1,0 +1,72 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import useFormContext from '../hooks/useFormContext'
+import EntitySearchWithDataProvider from '../../entity-search/EntitySearchWithDataProvider'
+import dnbCompanySearchDataProvider from '../../entity-search/data-providers/DnbCompanySearch'
+
+const FieldDnbCompany = ({
+  name,
+  label,
+  country,
+  apiEndpoint,
+}) => {
+  const { goBack, goForward, setFieldValue } = useFormContext()
+
+  return (
+    <div>
+      <label htmlFor={name}>{label}</label>
+
+      <EntitySearchWithDataProvider
+        getEntities={dnbCompanySearchDataProvider(apiEndpoint)}
+        previouslySelected={{
+          text: `Based in the ${country}`,
+          onChangeClick: goBack,
+        }}
+        entityFilters={[
+          [
+            {
+              label: 'Company name',
+              key: 'search_term',
+            },
+          ],
+          [
+            {
+              label: 'Company postcode',
+              key: 'postal_code',
+              width: 'one-half',
+              optional: true,
+            },
+          ],
+        ]}
+        cannotFind={{
+          summary: 'I cannot find the company I am looking for',
+          actions: [
+            'Check the country selected is correct',
+            'Check for spelling errors in the company name',
+            'Remove or add Ltd or Limited to your search',
+          ],
+          link: {
+            text: 'I still cannot find the company',
+            url: 'http://stillcannotfind.com',
+          },
+        }}
+        onEntityClick={(entity) => {
+          if (!entity.datahub_company) {
+            setFieldValue(name, entity.dnb_company)
+            goForward()
+          }
+        }}
+      />
+    </div>
+  )
+}
+
+FieldDnbCompany.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string.isRequired,
+  country: PropTypes.string.isRequired,
+  apiEndpoint: PropTypes.string.isRequired,
+}
+
+export default FieldDnbCompany

--- a/src/forms/elements/__stories__/FieldDnbCompany.stories.jsx
+++ b/src/forms/elements/__stories__/FieldDnbCompany.stories.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+
+import FieldDnbCompany from '../FieldDnbCompany'
+import Form from '../Form'
+import Step from '../Step'
+import { setupSuccessMocks } from '../../../entity-search/__mocks__/company-search'
+import { useFormContext } from '../../../index'
+
+const API_ENDPOINT = 'http://localhost:3010/v4/dnb/company-search'
+
+function Values() {
+  const form = useFormContext()
+  return (
+    <>
+      <pre>{JSON.stringify(form, null, 2)}</pre>
+    </>
+  )
+}
+
+storiesOf('Forms', module)
+  .add('FieldDnbCompany - Default', () => {
+    setupSuccessMocks(API_ENDPOINT)
+
+    return (
+      <Form onSubmit={action('onSubmit')}>
+        <Step name="first" hideForwardButton={true}>
+          <FieldDnbCompany
+            name="dnb_company"
+            label="Find the company"
+            country="UK"
+            apiEndpoint={API_ENDPOINT}
+          />
+        </Step>
+        <Step name="second">
+          <Values />
+        </Step>
+      </Form>
+    )
+  })

--- a/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
+++ b/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
@@ -1,0 +1,137 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import { act } from 'react-dom/test-utils'
+
+import Form from '../Form'
+import Step from '../Step'
+import FieldDnbCompany from '../FieldDnbCompany'
+import { setupSuccessMocks } from '../../../entity-search/__mocks__/company-search'
+import entitySearchFixtures from '../../../entity-search/__fixtures__'
+
+const API_ENDPOINT = 'http://localhost:3010/v4/dnb/company-search'
+
+const flushPromises = () => {
+  return new Promise((resolve) => {
+    setTimeout(resolve, 0)
+  })
+}
+
+describe('FieldDnbCompany', () => {
+  let wrapper
+
+  describe('when all fields have been specified', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <FieldDnbCompany
+            name="testField"
+            label="testLabel"
+            country="UK"
+            apiEndpoint={API_ENDPOINT}
+          />
+        </Form>,
+      )
+    })
+
+    test('should render the field with a label', () => {
+      expect(wrapper.find('label').at(0).text()).toEqual('testLabel')
+    })
+
+    test('should render the field with the previously selected country', () => {
+      expect(wrapper.find('p').text()).toContain('Based in the UK')
+    })
+
+    test('should render the field with filters', () => {
+      expect(wrapper.find('label').at(1).text()).toEqual('Company name')
+      expect(wrapper.find('[name="search_term"]').exists()).toBeTruthy()
+      expect(wrapper.find('label').at(2).text()).toEqual('Company postcode (optional)')
+      expect(wrapper.find('[name="postal_code"]').exists()).toBeTruthy()
+    })
+  })
+
+  describe('when the company country "Change" link is clicked', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form initialStep={1}>
+          {({ currentStep }) => (
+            <>
+              <div className="current-step">{currentStep}</div>
+              <FieldDnbCompany
+                name="testField"
+                label="testLabel"
+                country="UK"
+                apiEndpoint={API_ENDPOINT}
+              />
+            </>
+          )}
+        </Form>,
+      )
+
+      wrapper.find('[href="#previously-selected"]').at(0).simulate('click')
+    })
+
+    test('should go back to the first step', () => {
+      expect(wrapper.find('.current-step').text()).toEqual('0')
+    })
+  })
+
+  describe('when the "Search" button is clicked', () => {
+    beforeAll(async () => {
+      setupSuccessMocks(API_ENDPOINT)
+
+      wrapper = mount(
+        <Form initialStep={1}>
+          {({ currentStep, values }) => (
+            <>
+              <div className="current-step">{currentStep}</div>
+              <div className="field-value">{JSON.stringify(values.testField)}</div>
+
+              <Step name="first" />
+              <Step name="second">
+                <FieldDnbCompany
+                  name="testField"
+                  label="testLabel"
+                  country="UK"
+                  apiEndpoint={API_ENDPOINT}
+                />
+              </Step>
+              <Step name="third" />
+
+            </>
+          )}
+        </Form>,
+      )
+
+      wrapper.find('Search').simulate('click')
+
+      await act(flushPromises)
+
+      wrapper.update()
+    })
+
+    test('should render entities', () => {
+      const entityList = wrapper.find('ol')
+      expect(entityList.find('li').length).toEqual(2)
+    })
+
+    test('should render cannot find actions', () => {
+      const actionList = wrapper.find('ul')
+      expect(actionList.find('li').length).toEqual(3)
+    })
+
+    describe('when an entity is clicked', () => {
+      beforeAll(() => {
+        wrapper.find('StyledEntity').at(1).simulate('click')
+      })
+
+      test('should set the field value', () => {
+        const expected = JSON.stringify(entitySearchFixtures.companySearch.results[1].dnb_company)
+        expect(wrapper.find('.field-value').text()).toEqual(expected)
+      })
+
+      test('should go to the third step', () => {
+        expect(wrapper.find('.current-step').text()).toEqual('2')
+      })
+    })
+  })
+})


### PR DESCRIPTION
## Description of change
Adds the element `FieldDnbCompany` so that a component which searches and selects D&B companies is as follows:

```html
              <FieldDnbCompany
                name="dnb_company"
                label="Find the company"
                country={values.companyLocation}
                apiEndpoint={API_ENDPOINT}
              />
```

## Test instructions
An example of this element can be viewed on the second step of Storybook at `~/?path=/story/forms--multistep-add-d-b-company-form`.

## Screenshot
![Screenshot 2019-09-02 at 09 28 47](https://user-images.githubusercontent.com/1150417/64100735-1d174a00-cd64-11e9-803d-c41820a8de36.png)