### PR TITLE
feat: Add "required" prop to form fields to simplify validation

### DIFF
--- a/src/forms/elements/FieldInput.jsx
+++ b/src/forms/elements/FieldInput.jsx
@@ -5,8 +5,8 @@ import { RED } from 'govuk-colours'
 import useField from '../hooks/useField'
 import FieldError from './FieldError'
 
-const FieldInput = ({ name, type, validate, label, ...rest }) => {
-  const { value, error, onChange, onBlur } = useField({ name, label, validate })
+const FieldInput = ({ name, type, validate, required, label, ...rest }) => {
+  const { value, error, onChange, onBlur } = useField({ name, label, validate, required })
 
   return (
     <div>
@@ -29,16 +29,17 @@ const FieldInput = ({ name, type, validate, label, ...rest }) => {
   )
 }
 
-
 FieldInput.propTypes = {
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
   validate: PropTypes.func,
+  required: PropTypes.string,
   label: PropTypes.string,
 }
 
 FieldInput.defaultProps = {
   validate: null,
+  required: null,
   label: null,
 }
 

--- a/src/forms/elements/FieldRadios.jsx
+++ b/src/forms/elements/FieldRadios.jsx
@@ -5,8 +5,8 @@ import MultiChoice from '@govuk-react/multi-choice'
 
 import useField from '../hooks/useField'
 
-const FieldRadios = ({ name, validate, label, options, ...rest }) => {
-  const { value, error, touched, onChange, onBlur } = useField({ name, label, validate })
+const FieldRadios = ({ name, validate, required, label, options, ...rest }) => {
+  const { value, error, touched, onChange, onBlur } = useField({ name, label, validate, required })
 
   return (
     <div>
@@ -35,6 +35,7 @@ const FieldRadios = ({ name, validate, label, options, ...rest }) => {
 FieldRadios.propTypes = {
   name: PropTypes.string.isRequired,
   validate: PropTypes.func,
+  required: PropTypes.string,
   label: PropTypes.string,
   options: PropTypes.arrayOf(
     PropTypes.shape({
@@ -47,6 +48,7 @@ FieldRadios.propTypes = {
 
 FieldRadios.defaultProps = {
   validate: null,
+  required: null,
   label: null,
   options: [],
 }

--- a/src/forms/elements/FieldSelect.jsx
+++ b/src/forms/elements/FieldSelect.jsx
@@ -4,8 +4,8 @@ import Select from '@govuk-react/select'
 
 import useField from '../hooks/useField'
 
-const FieldSelect = ({ name, label, validate, options, emptyOption }) => {
-  const { error, touched, onChange, onBlur } = useField({ name, label, validate })
+const FieldSelect = ({ name, label, validate, required, options, emptyOption }) => {
+  const { error, touched, onChange, onBlur } = useField({ name, label, validate, required })
 
   return (
     <div>
@@ -34,6 +34,7 @@ FieldSelect.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.string,
   validate: PropTypes.func,
+  required: PropTypes.string,
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,
@@ -45,6 +46,7 @@ FieldSelect.propTypes = {
 
 FieldSelect.defaultProps = {
   validate: null,
+  required: null,
   label: null,
   options: [],
   emptyOption: 'Please select',

--- a/src/forms/elements/__stories__/FieldSelect.stories.jsx
+++ b/src/forms/elements/__stories__/FieldSelect.stories.jsx
@@ -19,7 +19,8 @@ storiesOf('Forms', module)
           { label: 'testOptionLabel1', value: 'testOptionValue1' },
           { label: 'testOptionLabel2', value: 'testOptionValue2' },
         ])}
-        validate={value => (!value ? text('error', 'This is an example error message') : null)}
+        required="Select one of the options"
+        validate={value => (value !== 'testOptionValue2' ? text('error', 'You need to select testOptionValue2') : null)}
       />
 
       <Button>Submit</Button>

--- a/src/forms/elements/__stories__/Form.stories.jsx
+++ b/src/forms/elements/__stories__/Form.stories.jsx
@@ -31,13 +31,13 @@ storiesOf('Forms', module)
             <StepHeader />
 
             <Step name="first">
-              <FieldInput type="number" name="age" label="Age" validate={value => (!value ? 'Age is required' : null)} />
-              <FieldInput type="number" name="height" label="Height" validate={value => (!value ? 'Height is required' : null)} />
+              <FieldInput type="number" name="age" label="Age" required="Enter age" />
+              <FieldInput type="number" name="height" label="Height" required="Enter height" />
 
               <FieldRadios
                 name="companyLocation"
                 label="Where is the company based?"
-                validate={value => (!value ? 'Please specify where the company is based' : null)}
+                required="Specify where the company is based"
                 options={[
                   { label: 'UK', value: 'uk' },
                   {
@@ -53,7 +53,8 @@ storiesOf('Forms', module)
               <FieldSelect
                 name="country"
                 label="Country"
-                validate={value => (!value ? 'Please specify where the company is based' : null)}
+                required="Chose one of the countries"
+                validate={value => (value !== 'it' ? 'You need to select Italy' : null)}
                 options={[
                   { label: 'Germany', value: 'de' },
                   { label: 'France', value: 'fr' },
@@ -64,13 +65,13 @@ storiesOf('Forms', module)
 
             {values.age === '1' && (
               <Step name="second" label="Add a Company">
-                <FieldInput type="text" name="name" label="Name" validate={value => (!value ? 'name is required' : null)} />
+                <FieldInput type="text" name="name" label="Name" required="Enter name" />
                 <FieldInput type="email" name="email" label="Email" />
               </Step>
             )}
 
             <Step name="third">
-              <FieldInput type="number" name="shoeSize" label="Shoe size" validate={value => (!value ? 'Shoe size is required' : null)} />
+              <FieldInput type="number" name="shoeSize" label="Shoe size" required="Enter shoe size" />
             </Step>
 
             <Step name="fourth">

--- a/src/forms/hooks/__tests__/useField.test.jsx
+++ b/src/forms/hooks/__tests__/useField.test.jsx
@@ -8,7 +8,6 @@ const TestField = (props) => {
   const field = useField({
     name: 'testField',
     label: 'testLabel',
-    validate: () => 'testError',
     ...props,
   })
 
@@ -30,17 +29,17 @@ const TestField = (props) => {
 }
 
 describe('useField', () => {
-  describe('when field is mounted with `initialValue`', () => {
-    let wrapper
-    let value
-    let input
-    let touched
-    let error
+  let wrapper
+  let value
+  let input
+  let touched
+  let error
 
+  describe('when field is mounted with `initialValue`', () => {
     beforeAll(() => {
       wrapper = mount(
         <Form>
-          <TestField initialValue="testInitialValue" />
+          <TestField initialValue="testInitialValue" validate={() => 'testError'} />
         </Form>,
       )
       value = wrapper.find('.value')
@@ -73,7 +72,7 @@ describe('useField', () => {
       })
     })
 
-    describe('when form is submitted', () => {
+    describe('when form is submitted without filling the field', () => {
       beforeAll(() => {
         wrapper.simulate('submit')
       })
@@ -82,6 +81,22 @@ describe('useField', () => {
         expect(touched.text()).toEqual('true')
         expect(error.text()).toEqual('testError')
       })
+    })
+  })
+
+  describe('when form is submitted without filling the required field', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <TestField required="testRequiredError" />
+        </Form>,
+      )
+      error = wrapper.find('.error')
+      wrapper.simulate('submit')
+    })
+
+    test('should return error for the required field', () => {
+      expect(error.text()).toEqual('testRequiredError')
     })
   })
 })

--- a/src/forms/hooks/useField.js
+++ b/src/forms/hooks/useField.js
@@ -1,8 +1,9 @@
 import { useEffect } from 'react'
+import { isEmpty } from 'lodash'
 
 import useFormContext from './useFormContext'
 
-function useField({ name, label, initialValue = '', validate = null }) {
+function useField({ name, label, initialValue = '', validate = null, required = null }) {
   const {
     registerField,
     deregisterField,
@@ -11,9 +12,19 @@ function useField({ name, label, initialValue = '', validate = null }) {
     getFieldState,
   } = useFormContext()
 
+  function prepareValidators() {
+    const validators = Array.isArray(validate) ? validate : [validate].filter(v => v)
+
+    if (required) {
+      validators.unshift(value => (isEmpty(value) ? required : null))
+    }
+
+    return validators
+  }
+
   useEffect(
     () => {
-      registerField({ name, label, initialValue, validate })
+      registerField({ name, label, initialValue, validate: prepareValidators() })
 
       return () => {
         deregisterField(name)


### PR DESCRIPTION
Old API:
```
<FieldSelect
  name="country"
  label="Country"
  validate={value => (!value ? 'Chose one of the countries' : null)}
  options={[
    { label: 'Germany', value: 'de' },
    { label: 'France', value: 'fr' },
    { label: 'Italy', value: 'it' },
  ]}
/>
```

New API:
```
<FieldSelect
  name="country"
  label="Country"
  required="Chose one of the countries"
  options={[
    { label: 'Germany', value: 'de' },
    { label: 'France', value: 'fr' },
    { label: 'Italy', value: 'it' },
  ]}
/>
```