### PR TITLE
Add StatusMessage to EntitySearch

### DIFF
--- a/src/entity-search/EntitySearch.jsx
+++ b/src/entity-search/EntitySearch.jsx
@@ -18,6 +18,7 @@ StyledButton.displayName = 'Search'
 const EntitySearch = ({
   previouslySelected,
   entityFilters,
+  entityListHeader,
   onEntitySearch,
   entities,
   cannotFind,
@@ -40,6 +41,8 @@ const EntitySearch = ({
 
       {entities && entities.length ? (
         <>
+          {entityListHeader}
+
           <EntityList entities={entities} onEntityClick={onEntityClick} />
           <CannotFindDetails {...cannotFind} />
         </>
@@ -70,6 +73,7 @@ EntitySearch.propTypes = {
       }),
     ),
   ).isRequired,
+  entityListHeader: PropTypes.node,
   cannotFind: PropTypes.shape({
     summary: PropTypes.string.isRequired,
     actions: PropTypes.arrayOf(PropTypes.string).isRequired,
@@ -89,6 +93,7 @@ EntitySearch.propTypes = {
 
 EntitySearch.defaultProps = {
   entities: null,
+  entityListHeader: null,
   previouslySelected: null,
   error: null,
 }

--- a/src/entity-search/__stories__/EntitySearch.stories.jsx
+++ b/src/entity-search/__stories__/EntitySearch.stories.jsx
@@ -10,7 +10,6 @@ import dataHubAddCompanyBackground from './images/data-hub-add-company.png'
 import dnbCompanySearchDataProvider from '../data-providers/DnbCompanySearch'
 import EntitySearchWithDataProvider from '../EntitySearchWithDataProvider'
 import StatusMessage from '../../status-message/StatusMessage'
-import { Info } from '../../status-message/StatusMessageVariant'
 
 const apiEndpoint = 'http://localhost:3010/v4/dnb/company-search'
 
@@ -102,7 +101,7 @@ storiesOf('EntitySearch', module)
     return (
       <EntitySearchForStorybook
         entityListHeader={(
-          <StatusMessage variant={Info}>
+          <StatusMessage>
             The search results below are verified company records from Dun & Bradstreet,
             an external and up to date source of company information.
           </StatusMessage>

--- a/src/entity-search/__stories__/EntitySearch.stories.jsx
+++ b/src/entity-search/__stories__/EntitySearch.stories.jsx
@@ -9,10 +9,12 @@ import { setupSuccessMocks, setupErrorMocks, setupNoResultsMocks } from '../__mo
 import dataHubAddCompanyBackground from './images/data-hub-add-company.png'
 import dnbCompanySearchDataProvider from '../data-providers/DnbCompanySearch'
 import EntitySearchWithDataProvider from '../EntitySearchWithDataProvider'
+import StatusMessage from '../../status-message/StatusMessage'
+import { Info } from '../../status-message/StatusMessageVariant'
 
 const apiEndpoint = 'http://localhost:3010/v4/dnb/company-search'
 
-const EntitySearchForStorybook = ({ previouslySelected, cannotFindLink }) => {
+const EntitySearchForStorybook = ({ previouslySelected, entityListHeader, cannotFindLink }) => {
   return (
     <Main>
       <GridRow>
@@ -42,6 +44,7 @@ const EntitySearchForStorybook = ({ previouslySelected, cannotFindLink }) => {
                 },
               ],
             ]}
+            entityListHeader={entityListHeader}
             cannotFind={{
               summary: 'I cannot find the company I am looking for',
               actions: [
@@ -68,6 +71,7 @@ EntitySearchForStorybook.propTypes = {
     text: PropTypes.string.isRequired,
     onChangeClick: PropTypes.func.isRequired,
   },
+  entityListHeader: PropTypes.node,
   cannotFindLink: {
     text: PropTypes.string.isRequired,
     url: PropTypes.string,
@@ -77,6 +81,7 @@ EntitySearchForStorybook.propTypes = {
 
 EntitySearchForStorybook.defaultProps = {
   previouslySelected: null,
+  entityListHeader: null,
   cannotFindLink: {
     text: 'I still cannot find the company',
     url: 'http://stillcannotfind.com',
@@ -89,6 +94,20 @@ storiesOf('EntitySearch', module)
 
     return (
       <EntitySearchForStorybook />
+    )
+  })
+  .add('Data Hub company search with entity list header', () => {
+    setupSuccessMocks()
+
+    return (
+      <EntitySearchForStorybook
+        entityListHeader={(
+          <StatusMessage variant={Info}>
+            The search results below are verified company records from Dun & Bradstreet,
+            an external and up to date source of company information.
+          </StatusMessage>
+        )}
+      />
     )
   })
   .add('Data Hub company search with cannot find link callback', () => {

--- a/src/entity-search/__tests__/EntitySearch.test.jsx
+++ b/src/entity-search/__tests__/EntitySearch.test.jsx
@@ -9,6 +9,8 @@ import CannotFindDetails from '../CannotFindDetails'
 import EntityList from '../EntityList'
 import EntityListItem from '../EntityListItem'
 import EntitySearchWithDataProvider from '../EntitySearchWithDataProvider'
+import StatusMessage from '../../status-message/StatusMessage'
+import { Info } from '../../status-message/StatusMessageVariant'
 
 const API_ENDPOINT = 'http://localhost:8000/v4/dnb/company-search'
 
@@ -25,6 +27,7 @@ const wrapEntitySearch = ({
     text: 'still cannot find',
   },
   onEntityClick = () => {},
+  entityListHeader,
 } = {}) => {
   return mount(<EntitySearchWithDataProvider
     previouslySelected={previouslySelected}
@@ -46,6 +49,7 @@ const wrapEntitySearch = ({
       link: cannotFindLink,
     }}
     onEntityClick={onEntityClick}
+    entityListHeader={entityListHeader}
   />)
 }
 
@@ -70,6 +74,14 @@ describe('EntitySearch', () => {
       expect(wrappedEntitySearch.find('Search').exists()).toBeTruthy()
     })
 
+    test('should not show the entity list header', () => {
+      expect(wrappedEntitySearch.find(StatusMessage).exists()).toBeFalsy()
+    })
+
+    test('should not show the entities', () => {
+      expect(wrappedEntitySearch.find(EntityList).exists()).toBeFalsy()
+    })
+
     test('should not show the entities', () => {
       expect(wrappedEntitySearch.find(EntityList).exists()).toBeFalsy()
     })
@@ -78,7 +90,7 @@ describe('EntitySearch', () => {
       expect(wrappedEntitySearch.find(CannotFindDetails).exists()).toBeFalsy()
     })
 
-    describe('when the "Search" button is click', () => {
+    describe('when the "Search" button is clicked', () => {
       const preventDefaultSpy = jest.fn()
 
       beforeAll(async () => {
@@ -93,6 +105,10 @@ describe('EntitySearch', () => {
 
       test('should prevent the default button action', () => {
         expect(preventDefaultSpy.mock.calls.length).toEqual(1)
+      })
+
+      test('should not show the entity list header', () => {
+        expect(wrappedEntitySearch.find(StatusMessage).exists()).toBeFalsy()
       })
 
       test('should show the entities', () => {
@@ -203,7 +219,6 @@ describe('EntitySearch', () => {
     })
   })
 
-
   describe('when there is a previously selected "Change" link which is clicked', () => {
     let wrappedEntitySearch
     const onChangeClickSpy = jest.fn()
@@ -237,6 +252,40 @@ describe('EntitySearch', () => {
 
     test('should call the onChangeClick event', () => {
       expect(onChangeClickSpy.mock.calls.length).toEqual(1)
+    })
+  })
+
+  describe('when the entity list header is a status message', () => {
+    describe('when loading the entity search component', () => {
+      let wrappedEntitySearch
+
+      beforeAll(() => {
+        setupSuccessMocks(API_ENDPOINT)
+
+        wrappedEntitySearch = wrapEntitySearch({
+          entityListHeader: <StatusMessage variant={Info}>Some info</StatusMessage>,
+        })
+      })
+
+      test('should not show the entity list header', () => {
+        expect(wrappedEntitySearch.find(StatusMessage).exists()).toBeFalsy()
+      })
+
+      describe('when the "Search" button is clicked', () => {
+        beforeAll(async () => {
+          wrappedEntitySearch
+            .find('Search')
+            .simulate('click')
+
+          await act(flushPromises)
+
+          wrappedEntitySearch.update()
+        })
+
+        test('should show the entity list header', () => {
+          expect(wrappedEntitySearch.find(StatusMessage).exists()).toBeTruthy()
+        })
+      })
     })
   })
 

--- a/src/entity-search/__tests__/EntitySearch.test.jsx
+++ b/src/entity-search/__tests__/EntitySearch.test.jsx
@@ -10,7 +10,6 @@ import EntityList from '../EntityList'
 import EntityListItem from '../EntityListItem'
 import EntitySearchWithDataProvider from '../EntitySearchWithDataProvider'
 import StatusMessage from '../../status-message/StatusMessage'
-import { Info } from '../../status-message/StatusMessageVariant'
 
 const API_ENDPOINT = 'http://localhost:8000/v4/dnb/company-search'
 
@@ -263,7 +262,7 @@ describe('EntitySearch', () => {
         setupSuccessMocks(API_ENDPOINT)
 
         wrappedEntitySearch = wrapEntitySearch({
-          entityListHeader: <StatusMessage variant={Info}>Some info</StatusMessage>,
+          entityListHeader: <StatusMessage>Some info</StatusMessage>,
         })
       })
 

--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -5,6 +5,8 @@ import FormGroup from '@govuk-react/form-group'
 import useFormContext from '../hooks/useFormContext'
 import EntitySearchWithDataProvider from '../../entity-search/EntitySearchWithDataProvider'
 import dnbCompanySearchDataProvider from '../../entity-search/data-providers/DnbCompanySearch'
+import StatusMessage from '../../status-message/StatusMessage'
+import { Info } from '../../status-message/StatusMessageVariant'
 
 const FieldDnbCompany = ({
   name,
@@ -58,6 +60,12 @@ const FieldDnbCompany = ({
             goForward()
           }
         }}
+        entityListHeader={(
+          <StatusMessage variant={Info}>
+            The search results below are verified company records from Dun & Bradstreet,
+            an external and up to date source of company information.
+          </StatusMessage>
+        )}
       />
     </FormGroup>
   )

--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -6,7 +6,6 @@ import useFormContext from '../hooks/useFormContext'
 import EntitySearchWithDataProvider from '../../entity-search/EntitySearchWithDataProvider'
 import dnbCompanySearchDataProvider from '../../entity-search/data-providers/DnbCompanySearch'
 import StatusMessage from '../../status-message/StatusMessage'
-import { Info } from '../../status-message/StatusMessageVariant'
 
 const FieldDnbCompany = ({
   name,
@@ -61,7 +60,7 @@ const FieldDnbCompany = ({
           }
         }}
         entityListHeader={(
-          <StatusMessage variant={Info}>
+          <StatusMessage>
             The search results below are verified company records from Dun & Bradstreet,
             an external and up to date source of company information.
           </StatusMessage>

--- a/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
+++ b/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
@@ -7,6 +7,7 @@ import EntityList from '../../../entity-search/EntityList'
 import EntityListItem from '../../../entity-search/EntityListItem'
 import FieldDnbCompany from '../FieldDnbCompany'
 import Form from '../Form'
+import StatusMessage from '../../../status-message/StatusMessage'
 import Step from '../Step'
 import { setupSuccessMocks } from '../../../entity-search/__mocks__/company-search'
 import entitySearchFixtures from '../../../entity-search/__fixtures__'
@@ -49,6 +50,10 @@ describe('FieldDnbCompany', () => {
       expect(wrapper.find('[name="search_term"]').exists()).toBeTruthy()
       expect(wrapper.find('label').at(2).text()).toEqual('Company postcode (optional)')
       expect(wrapper.find('[name="postal_code"]').exists()).toBeTruthy()
+    })
+
+    test('should not initially render the field with an entity list header', () => {
+      expect(wrapper.find(StatusMessage).exists()).toBeFalsy()
     })
   })
 
@@ -110,6 +115,10 @@ describe('FieldDnbCompany', () => {
       await act(flushPromises)
 
       wrapper.update()
+    })
+
+    test('should render the field with an entity list header', () => {
+      expect(wrapper.find(StatusMessage).exists()).toBeTruthy()
     })
 
     test('should render entities', () => {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -24,3 +24,6 @@ export { default as FieldDnbCompany } from './forms/elements/FieldDnbCompany'
 export { default as FieldInput } from './forms/elements/FieldInput'
 export { default as FieldRadios } from './forms/elements/FieldRadios'
 export { default as FieldSelect } from './forms/elements/FieldSelect'
+
+// Status message
+export { default as StatusMessage } from './status-message/StatusMessage'

--- a/src/status-message/StatusMessage.jsx
+++ b/src/status-message/StatusMessage.jsx
@@ -1,0 +1,43 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { SPACING } from '@govuk-react/constants'
+import { ERROR_COLOUR, BLUE, GREEN, ORANGE } from 'govuk-colours'
+
+import { Error, Info, Success, Warning } from './StatusMessageVariant'
+
+const Colours = {
+  [Error]: ERROR_COLOUR,
+  [Info]: BLUE,
+  [Success]: GREEN,
+  [Warning]: ORANGE,
+}
+
+const StyledStatusMessage = styled('div')`
+  border: ${({ variant }) => `${SPACING.SCALE_1} solid ${Colours[variant]}`};
+  color: ${({ variant }) => Colours[variant]};
+  padding: ${SPACING.SCALE_3};
+  margin-top: ${SPACING.SCALE_2};
+  font-weight: bold;
+  line-height: 1.5;
+`
+
+const StatusMessage = ({ variant, children }) => {
+  return (
+    <StyledStatusMessage variant={variant}>
+      {children}
+    </StyledStatusMessage>
+  )
+}
+
+StatusMessage.propTypes = {
+  variant: PropTypes.oneOf([
+    Error,
+    Info,
+    Success,
+    Warning,
+  ]).isRequired,
+  children: PropTypes.node.isRequired,
+}
+
+export default StatusMessage

--- a/src/status-message/StatusMessage.jsx
+++ b/src/status-message/StatusMessage.jsx
@@ -2,42 +2,32 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { SPACING } from '@govuk-react/constants'
-import { ERROR_COLOUR, BLUE, GREEN, ORANGE } from 'govuk-colours'
-
-import { Error, Info, Success, Warning } from './StatusMessageVariant'
-
-const Colours = {
-  [Error]: ERROR_COLOUR,
-  [Info]: BLUE,
-  [Success]: GREEN,
-  [Warning]: ORANGE,
-}
+import { BLUE } from 'govuk-colours'
 
 const StyledStatusMessage = styled('div')`
-  border: ${({ variant }) => `${SPACING.SCALE_1} solid ${Colours[variant]}`};
-  color: ${({ variant }) => Colours[variant]};
+  border: ${({ colour }) => `${SPACING.SCALE_1} solid ${colour}`};
+  color: ${({ colour }) => colour};
   padding: ${SPACING.SCALE_3};
   margin-top: ${SPACING.SCALE_2};
   font-weight: bold;
   line-height: 1.5;
 `
 
-const StatusMessage = ({ variant, children }) => {
+const StatusMessage = ({ colour, children }) => {
   return (
-    <StyledStatusMessage variant={variant}>
+    <StyledStatusMessage colour={colour}>
       {children}
     </StyledStatusMessage>
   )
 }
 
 StatusMessage.propTypes = {
-  variant: PropTypes.oneOf([
-    Error,
-    Info,
-    Success,
-    Warning,
-  ]).isRequired,
+  colour: PropTypes.string,
   children: PropTypes.node.isRequired,
+}
+
+StatusMessage.defaultProps = {
+  colour: BLUE,
 }
 
 export default StatusMessage

--- a/src/status-message/StatusMessageVariant.js
+++ b/src/status-message/StatusMessageVariant.js
@@ -1,4 +1,0 @@
-export const Error = 'error'
-export const Info = 'info'
-export const Success = 'success'
-export const Warning = 'warning'

--- a/src/status-message/StatusMessageVariant.js
+++ b/src/status-message/StatusMessageVariant.js
@@ -1,0 +1,4 @@
+export const Error = 'error'
+export const Info = 'info'
+export const Success = 'success'
+export const Warning = 'warning'

--- a/src/status-message/__stories__/StatusMessage.stories.jsx
+++ b/src/status-message/__stories__/StatusMessage.stories.jsx
@@ -1,27 +1,17 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
+import { ERROR_COLOUR } from 'govuk-colours'
 
 import StatusMessage from '../StatusMessage'
-import { Error, Info, Success, Warning } from '../StatusMessageVariant'
 
 storiesOf('StatusMessage', module)
-  .add('Error', () => {
+  .add('Default', () => {
     return (
-      <StatusMessage variant={Error}>An error message</StatusMessage>
+      <StatusMessage>An info message</StatusMessage>
     )
   })
-  .add('Info', () => {
+  .add('Custom colour', () => {
     return (
-      <StatusMessage variant={Info}>An error message</StatusMessage>
-    )
-  })
-  .add('Success', () => {
-    return (
-      <StatusMessage variant={Success}>A success message</StatusMessage>
-    )
-  })
-  .add('Warning', () => {
-    return (
-      <StatusMessage variant={Warning}>A warning message</StatusMessage>
+      <StatusMessage colour={ERROR_COLOUR}>An error message</StatusMessage>
     )
   })

--- a/src/status-message/__stories__/StatusMessage.stories.jsx
+++ b/src/status-message/__stories__/StatusMessage.stories.jsx
@@ -1,0 +1,27 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import StatusMessage from '../StatusMessage'
+import { Error, Info, Success, Warning } from '../StatusMessageVariant'
+
+storiesOf('StatusMessage', module)
+  .add('Error', () => {
+    return (
+      <StatusMessage variant={Error}>An error message</StatusMessage>
+    )
+  })
+  .add('Info', () => {
+    return (
+      <StatusMessage variant={Info}>An error message</StatusMessage>
+    )
+  })
+  .add('Success', () => {
+    return (
+      <StatusMessage variant={Success}>A success message</StatusMessage>
+    )
+  })
+  .add('Warning', () => {
+    return (
+      <StatusMessage variant={Warning}>A warning message</StatusMessage>
+    )
+  })

--- a/src/status-message/__tests__/StatusMessage.test.jsx
+++ b/src/status-message/__tests__/StatusMessage.test.jsx
@@ -1,40 +1,19 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import { ERROR_COLOUR } from 'govuk-colours'
 
 import StatusMessage from '../StatusMessage'
-import { Error, Info, Success, Warning } from '../StatusMessageVariant'
 
-const wrapStatusMessage = variant => (
-  mount(<StatusMessage variant={variant}>status message</StatusMessage>)
+const wrapStatusMessage = colour => (
+  mount(<StatusMessage colour={colour}>status message</StatusMessage>)
 )
 
 describe('StatusMessage', () => {
-  describe('Error', () => {
+  describe('Default', () => {
     let wrappedStatusMessage
 
     beforeAll(() => {
-      wrappedStatusMessage = wrapStatusMessage(Error)
-    })
-
-    test('should set the content with children', () => {
-      expect(wrappedStatusMessage.text()).toEqual('status message')
-    })
-
-    test('should have styles', () => {
-      expect(wrappedStatusMessage).toHaveStyleRule('border', '5px solid #b10e1e')
-      expect(wrappedStatusMessage).toHaveStyleRule('color', '#b10e1e')
-      expect(wrappedStatusMessage).toHaveStyleRule('padding', '15px')
-      expect(wrappedStatusMessage).toHaveStyleRule('margin-top', '10px')
-      expect(wrappedStatusMessage).toHaveStyleRule('font-weight', 'bold')
-      expect(wrappedStatusMessage).toHaveStyleRule('line-height', '1.5')
-    })
-  })
-
-  describe('Info', () => {
-    let wrappedStatusMessage
-
-    beforeAll(() => {
-      wrappedStatusMessage = wrapStatusMessage(Info)
+      wrappedStatusMessage = wrapStatusMessage()
     })
 
     test('should set the content with children', () => {
@@ -51,11 +30,11 @@ describe('StatusMessage', () => {
     })
   })
 
-  describe('Success', () => {
+  describe('With custom colour', () => {
     let wrappedStatusMessage
 
     beforeAll(() => {
-      wrappedStatusMessage = wrapStatusMessage(Success)
+      wrappedStatusMessage = wrapStatusMessage(ERROR_COLOUR)
     })
 
     test('should set the content with children', () => {
@@ -63,29 +42,8 @@ describe('StatusMessage', () => {
     })
 
     test('should have styles', () => {
-      expect(wrappedStatusMessage).toHaveStyleRule('border', '5px solid #006435')
-      expect(wrappedStatusMessage).toHaveStyleRule('color', '#006435')
-      expect(wrappedStatusMessage).toHaveStyleRule('padding', '15px')
-      expect(wrappedStatusMessage).toHaveStyleRule('margin-top', '10px')
-      expect(wrappedStatusMessage).toHaveStyleRule('font-weight', 'bold')
-      expect(wrappedStatusMessage).toHaveStyleRule('line-height', '1.5')
-    })
-  })
-
-  describe('Warning', () => {
-    let wrappedStatusMessage
-
-    beforeAll(() => {
-      wrappedStatusMessage = wrapStatusMessage(Warning)
-    })
-
-    test('should set the content with children', () => {
-      expect(wrappedStatusMessage.text()).toEqual('status message')
-    })
-
-    test('should have styles', () => {
-      expect(wrappedStatusMessage).toHaveStyleRule('border', '5px solid #f47738')
-      expect(wrappedStatusMessage).toHaveStyleRule('color', '#f47738')
+      expect(wrappedStatusMessage).toHaveStyleRule('border', '5px solid #b10e1e')
+      expect(wrappedStatusMessage).toHaveStyleRule('color', '#b10e1e')
       expect(wrappedStatusMessage).toHaveStyleRule('padding', '15px')
       expect(wrappedStatusMessage).toHaveStyleRule('margin-top', '10px')
       expect(wrappedStatusMessage).toHaveStyleRule('font-weight', 'bold')

--- a/src/status-message/__tests__/StatusMessage.test.jsx
+++ b/src/status-message/__tests__/StatusMessage.test.jsx
@@ -1,0 +1,95 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import StatusMessage from '../StatusMessage'
+import { Error, Info, Success, Warning } from '../StatusMessageVariant'
+
+const wrapStatusMessage = variant => (
+  mount(<StatusMessage variant={variant}>status message</StatusMessage>)
+)
+
+describe('StatusMessage', () => {
+  describe('Error', () => {
+    let wrappedStatusMessage
+
+    beforeAll(() => {
+      wrappedStatusMessage = wrapStatusMessage(Error)
+    })
+
+    test('should set the content with children', () => {
+      expect(wrappedStatusMessage.text()).toEqual('status message')
+    })
+
+    test('should have styles', () => {
+      expect(wrappedStatusMessage).toHaveStyleRule('border', '5px solid #b10e1e')
+      expect(wrappedStatusMessage).toHaveStyleRule('color', '#b10e1e')
+      expect(wrappedStatusMessage).toHaveStyleRule('padding', '15px')
+      expect(wrappedStatusMessage).toHaveStyleRule('margin-top', '10px')
+      expect(wrappedStatusMessage).toHaveStyleRule('font-weight', 'bold')
+      expect(wrappedStatusMessage).toHaveStyleRule('line-height', '1.5')
+    })
+  })
+
+  describe('Info', () => {
+    let wrappedStatusMessage
+
+    beforeAll(() => {
+      wrappedStatusMessage = wrapStatusMessage(Info)
+    })
+
+    test('should set the content with children', () => {
+      expect(wrappedStatusMessage.text()).toEqual('status message')
+    })
+
+    test('should have styles', () => {
+      expect(wrappedStatusMessage).toHaveStyleRule('border', '5px solid #005ea5')
+      expect(wrappedStatusMessage).toHaveStyleRule('color', '#005ea5')
+      expect(wrappedStatusMessage).toHaveStyleRule('padding', '15px')
+      expect(wrappedStatusMessage).toHaveStyleRule('margin-top', '10px')
+      expect(wrappedStatusMessage).toHaveStyleRule('font-weight', 'bold')
+      expect(wrappedStatusMessage).toHaveStyleRule('line-height', '1.5')
+    })
+  })
+
+  describe('Success', () => {
+    let wrappedStatusMessage
+
+    beforeAll(() => {
+      wrappedStatusMessage = wrapStatusMessage(Success)
+    })
+
+    test('should set the content with children', () => {
+      expect(wrappedStatusMessage.text()).toEqual('status message')
+    })
+
+    test('should have styles', () => {
+      expect(wrappedStatusMessage).toHaveStyleRule('border', '5px solid #006435')
+      expect(wrappedStatusMessage).toHaveStyleRule('color', '#006435')
+      expect(wrappedStatusMessage).toHaveStyleRule('padding', '15px')
+      expect(wrappedStatusMessage).toHaveStyleRule('margin-top', '10px')
+      expect(wrappedStatusMessage).toHaveStyleRule('font-weight', 'bold')
+      expect(wrappedStatusMessage).toHaveStyleRule('line-height', '1.5')
+    })
+  })
+
+  describe('Warning', () => {
+    let wrappedStatusMessage
+
+    beforeAll(() => {
+      wrappedStatusMessage = wrapStatusMessage(Warning)
+    })
+
+    test('should set the content with children', () => {
+      expect(wrappedStatusMessage.text()).toEqual('status message')
+    })
+
+    test('should have styles', () => {
+      expect(wrappedStatusMessage).toHaveStyleRule('border', '5px solid #f47738')
+      expect(wrappedStatusMessage).toHaveStyleRule('color', '#f47738')
+      expect(wrappedStatusMessage).toHaveStyleRule('padding', '15px')
+      expect(wrappedStatusMessage).toHaveStyleRule('margin-top', '10px')
+      expect(wrappedStatusMessage).toHaveStyleRule('font-weight', 'bold')
+      expect(wrappedStatusMessage).toHaveStyleRule('line-height', '1.5')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change
This change introduces a status message component. This is a common pattern used across Data Hub. In this particular instance it is required for displaying information at the top of the entity search component.

This change includes:
- `StatusMessage` component
- integrating component with existing entity search
- integrating component with `FieldDnbCompany`

## Test instructions
Browse to any:
- `/?path=/story/statusmessage--default`
- `/?path=/story/statusmessage--custom-colour`
- `/?path=/story/entitysearch--data-hub-company-search-with-entity-list-header`, click 
- `/?path=/story/forms--fielddnbcompany-default`, click `Search`

## Screenshots
### StatusMessage
<img width="1244" alt="Screenshot 2019-09-09 at 16 34 57" src="https://user-images.githubusercontent.com/1150417/64544928-cab7c980-d31f-11e9-8051-5f11a789c093.png">
<img width="1243" alt="Screenshot 2019-09-09 at 15 31 51" src="https://user-images.githubusercontent.com/1150417/64539821-16b24080-d317-11e9-8a19-9e02aed8ea2a.png">

### EntitySearch
<img width="896" alt="Screenshot 2019-09-09 at 15 32 31" src="https://user-images.githubusercontent.com/1150417/64539896-35183c00-d317-11e9-8107-726ae6378f3b.png">

### Field DnbCompany
<img width="1242" alt="Screenshot 2019-09-09 at 15 32 21" src="https://user-images.githubusercontent.com/1150417/64539907-3ba6b380-d317-11e9-8dff-cf93084311ac.png">
