### PR TITLE
fix: Update cannot find words based on feedback

### DIFF
--- a/src/entity-search/CannotFindDetails.jsx
+++ b/src/entity-search/CannotFindDetails.jsx
@@ -25,7 +25,7 @@ const CannotFindDetails = ({ summary, actions, link }) => {
   return (
     <StyledDetails summary={summary}>
       <div>
-        <Paragraph>Try refining your search by taking the following actions:</Paragraph>
+        <Paragraph>Try improving your search by:</Paragraph>
         <StyledList>
           {actions.map(text => <li key={uniqueId()}>{text}</li>)}
         </StyledList>

--- a/src/entity-search/__stories__/EntitySearch.stories.jsx
+++ b/src/entity-search/__stories__/EntitySearch.stories.jsx
@@ -47,9 +47,9 @@ const EntitySearchForStorybook = ({ previouslySelected, entityListHeader, cannot
             cannotFind={{
               summary: 'I cannot find the company I am looking for',
               actions: [
-                'Check the country selected is correct',
-                'Check for spelling errors in the company name',
-                'Remove or add Ltd or Limited to your search',
+                'checking the company name for spelling errors',
+                'making sure you selected the correct country',
+                'adding a postcode to your search to narrow down the results',
               ],
               link: cannotFindLink,
             }}

--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -44,9 +44,9 @@ const FieldDnbCompany = ({
         cannotFind={{
           summary: 'I cannot find the company I am looking for',
           actions: [
-            'Check the country selected is correct',
-            'Check for spelling errors in the company name',
-            'Remove or add Ltd or Limited to your search',
+            'checking the company name for spelling errors',
+            'making sure you selected the correct country',
+            'adding a postcode to your search to narrow down the results',
           ],
           link: {
             text: 'I still cannot find the company',


### PR DESCRIPTION
## Description of change
Based upon user feedback, he `CannotFindDetails` section after the search results is being updated so that the information is easier to understand.

## Test instructions
1. Browse to Storybook
2. Browse to `FieldDnbCompany`
3. Click "Search"
4. Click "I cannot find the company I am looking for", the updated wording should be presented

## Before
<img width="1237" alt="Screenshot 2019-09-09 at 16 55 33" src="https://user-images.githubusercontent.com/1150417/64546572-dc4ea080-d322-11e9-8764-d0f153b96e23.png">

## After
<img width="1253" alt="Screenshot 2019-09-09 at 16 55 07" src="https://user-images.githubusercontent.com/1150417/64546561-d789ec80-d322-11e9-8176-5b9bfd37bd48.png">