### PR TITLE
fix: Display forms back button as link

### DIFF
--- a/src/forms/elements/Step.jsx
+++ b/src/forms/elements/Step.jsx
@@ -1,9 +1,21 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
 import { Button } from 'govuk-react'
-import { BLACK, GREY_2 } from 'govuk-colours'
+import { LINK_COLOUR } from 'govuk-colours'
+import styled from 'styled-components'
 
 import useFormContext from '../hooks/useFormContext'
+
+const StyledBackButton = styled(Button)`
+  &, &:hover, &:focus {
+    background: transparent;
+    box-shadow: none;
+    color: ${LINK_COLOUR};
+    cursor: pointer;
+    text-align: left;
+    text-decoration: underline;
+  }
+`
 
 function Step({
   name, backButtonText, forwardButtonText,
@@ -37,20 +49,15 @@ function Step({
     <>
       {children}
 
-      {!hideBackButton && !isFirstStep() && (
-        <Button
-          buttonColour={GREY_2}
-          buttonTextColour={BLACK}
-          type="button"
-          onClick={goBack}
-        >
-          {backButtonText || defaultBackButtonText}
-        </Button>
-      )}
+      {!hideForwardButton && <Button>{forwardButtonText || defaultForwardButtonText}</Button>}
 
       {' '}
 
-      {!hideForwardButton && <Button>{forwardButtonText || defaultForwardButtonText}</Button>}
+      {!hideBackButton && !isFirstStep() && (
+        <StyledBackButton onClick={goBack}>
+          {backButtonText || defaultBackButtonText}
+        </StyledBackButton>
+      )}
     </>
   )
 }

--- a/src/forms/elements/__stories__/FieldDnbCompany.stories.jsx
+++ b/src/forms/elements/__stories__/FieldDnbCompany.stories.jsx
@@ -20,7 +20,7 @@ function Values() {
 }
 
 storiesOf('Forms', module)
-  .add('FieldDnbCompany - Default', () => {
+  .add('FieldDnbCompany', () => {
     setupSuccessMocks(API_ENDPOINT)
 
     return (

--- a/src/forms/elements/__stories__/FieldRadios.stories.jsx
+++ b/src/forms/elements/__stories__/FieldRadios.stories.jsx
@@ -1,0 +1,47 @@
+import React from 'react'
+import { addDecorator, storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions/dist/index'
+import { withKnobs } from '@storybook/addon-knobs'
+import Button from '@govuk-react/button'
+
+import FieldRadios from '../FieldRadios'
+import Form from '../Form'
+import FieldSelect from '../FieldSelect'
+
+addDecorator(withKnobs)
+
+storiesOf('Forms', module)
+  .add('FieldRadios', () => (
+    <Form onSubmit={action('onSubmit')}>
+      {form => (
+        <>
+          <FieldRadios
+            name="companyLocation"
+            label="Where is the company based?"
+            required="Specify where the company is based"
+            options={[
+              { label: 'UK', value: 'uk' },
+              {
+                label: 'Overseas',
+                value: 'overseas',
+                children: (
+                  <FieldSelect
+                    name="country"
+                    label="Country"
+                    required="Child elements validate too!"
+                    options={[
+                      { label: 'Germany', value: 'de' },
+                      { label: 'France', value: 'fr' },
+                      { label: 'Italy', value: 'it' },
+                    ]}
+                  />
+                ),
+              },
+            ]}
+          />
+          <Button>Submit</Button>
+          <pre>{JSON.stringify(form, null, 2)}</pre>
+        </>
+      )}
+    </Form>
+  ))

--- a/src/forms/elements/__stories__/FieldSelect.stories.jsx
+++ b/src/forms/elements/__stories__/FieldSelect.stories.jsx
@@ -10,7 +10,7 @@ import Form from '../Form'
 addDecorator(withKnobs)
 
 storiesOf('Forms', module)
-  .add('FieldSelect - Default', () => (
+  .add('FieldSelect', () => (
     <Form onSubmit={action('onSubmit')}>
       {form => (
         <>

--- a/src/forms/elements/__stories__/Form.stories.jsx
+++ b/src/forms/elements/__stories__/Form.stories.jsx
@@ -23,7 +23,7 @@ function StepHeader() {
 }
 
 storiesOf('Forms', module)
-  .add('Multistep Example Form', () => {
+  .add('Form - Full example', () => {
     return (
       <Form onSubmit={action('onSubmit')}>
         {({ values }) => (

--- a/src/forms/elements/__stories__/Step.stories.jsx
+++ b/src/forms/elements/__stories__/Step.stories.jsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+
+import { Form, Step, useFormContext } from '../../../index'
+
+function Values() {
+  const form = useFormContext()
+  const debug = {
+    ...form,
+    isFirstStep: form.isFirstStep(),
+    isLastStep: form.isLastStep(),
+  }
+
+  return (
+    <>
+      <pre>{JSON.stringify(debug, null, 2)}</pre>
+    </>
+  )
+}
+
+function StepHeader() {
+  const { currentStep, steps } = useFormContext()
+  return (
+    <div>Step {currentStep + 1} of {steps.length}</div>
+  )
+}
+
+storiesOf('Forms', module)
+  .add('Step', () => {
+    return (
+      <Form onSubmit={action('onSubmit')}>
+        <StepHeader />
+
+        <Step name="first">
+          <Values />
+        </Step>
+
+        <Step name="second" forwardButtonText="GO FORWARD!" backButtonText="GO BACK!">
+          <Values />
+
+          <p>Custom button labels <span role="img">⬇</span>️</p>
+        </Step>
+
+        <Step name="third">
+          <Values />
+        </Step>
+
+        <Step name="fourth">
+          <Values />
+        </Step>
+      </Form>
+    )
+  })

--- a/src/forms/elements/__tests__/Step.test.jsx
+++ b/src/forms/elements/__tests__/Step.test.jsx
@@ -256,7 +256,7 @@ describe('Step', () => {
 
         describe('when the "Back" button is clicked', () => {
           beforeAll(() => {
-            const prevButton = wrapper.find('button').at(0)
+            const prevButton = wrapper.find('button').at(1)
             prevButton.simulate('click')
             formState = JSON.parse(wrapper.find('.form-state').text())
           })
@@ -289,7 +289,7 @@ describe('Step', () => {
     })
 
     test('should render a back button with modified step', () => {
-      expect(wrapper.find('button').at(0).text()).toEqual('testForwardButtonText')
+      expect(wrapper.find('button').text()).toEqual('testForwardButtonText')
     })
   })
 
@@ -304,7 +304,7 @@ describe('Step', () => {
     })
 
     test('should render a back button with modified step', () => {
-      expect(wrapper.find('button').at(0).text()).toEqual('testBackButtonText')
+      expect(wrapper.find('button').at(1).text()).toEqual('testBackButtonText')
     })
   })
 


### PR DESCRIPTION
Change required to match the designs.

## Before

![image](https://user-images.githubusercontent.com/4199239/64607106-b925fe80-d3bf-11e9-8e06-d1fae4510312.png)


## After

![image](https://user-images.githubusercontent.com/4199239/64607082-aad7e280-d3bf-11e9-8b75-5caa2e4e4be9.png)
