### PR TITLE
feat: Add FieldUneditable

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "@govuk-react/select": "^0.7.1",
     "@govuk-react/table": "^0.7.1",
     "@govuk-react/unordered-list": "^0.7.1",
+    "@govuk-react/visually-hidden": "^0.7.1",
     "axios": "^0.19.0",
     "constate": "^1.2.0",
     "govuk-colours": "^1.0.3",

--- a/src/forms/elements/FieldUneditable.jsx
+++ b/src/forms/elements/FieldUneditable.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import VisuallyHidden from '@govuk-react/visually-hidden'
+
+import FieldWrapper from './FieldWrapper'
+import ButtonLink from '../../button-link/ButtonLink'
+
+const FieldUneditable = ({ name, label, legend, hint, onChangeClick, children }) => {
+  return (
+    <FieldWrapper {...({ name, label, legend, hint })}>
+      {children}
+      {' '}
+      {onChangeClick && (
+        <ButtonLink
+          inline={true}
+          onClick={onChangeClick}
+        >
+          Change <VisuallyHidden>{label}</VisuallyHidden>
+        </ButtonLink>
+      )}
+    </FieldWrapper>
+  )
+}
+
+FieldUneditable.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.string,
+  legend: PropTypes.string,
+  hint: PropTypes.string,
+  onChangeClick: PropTypes.func,
+  children: PropTypes.node.isRequired,
+}
+
+FieldUneditable.defaultProps = {
+  label: null,
+  legend: null,
+  hint: null,
+  onChangeClick: null,
+}
+
+export default FieldUneditable

--- a/src/forms/elements/__stories__/FieldUneditable.stories.jsx
+++ b/src/forms/elements/__stories__/FieldUneditable.stories.jsx
@@ -1,0 +1,23 @@
+import React from 'react'
+import { addDecorator, storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+import { withKnobs } from '@storybook/addon-knobs'
+
+import Form from '../Form'
+import FieldUneditable from '../FieldUneditable'
+
+addDecorator(withKnobs)
+
+storiesOf('Forms', module)
+  .add('FieldUneditable', () => (
+    <Form>
+      <FieldUneditable
+        name="testField"
+        label="Country"
+        hint="Your selection from the previous step"
+        onChangeClick={action('onChangeClick')}
+      >
+        United Kingdom
+      </FieldUneditable>
+    </Form>
+  ))

--- a/src/forms/elements/__tests__/FieldUneditable.test.jsx
+++ b/src/forms/elements/__tests__/FieldUneditable.test.jsx
@@ -1,0 +1,100 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import HintText from '@govuk-react/hint-text'
+import Label from '@govuk-react/label'
+
+import Form from '../Form'
+import FieldUneditable from '../FieldUneditable'
+import ButtonLink from '../../../button-link/ButtonLink'
+
+describe('FieldUneditable', () => {
+  let wrapper
+
+  describe('when the field does specify a label', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <FieldUneditable name="testField" label="testLabel">testValue</FieldUneditable>
+        </Form>,
+      )
+    })
+
+    test('should render the value', () => {
+      expect(wrapper.text()).toContain('testValue')
+    })
+
+    test('should render the field with a label', () => {
+      expect(wrapper.find(Label).text()).toEqual('testLabel')
+    })
+  })
+
+  describe('when the field does not specify a label', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <FieldUneditable name="testField">testValue</FieldUneditable>
+        </Form>,
+      )
+    })
+
+    test('should render the field without a label', () => {
+      expect(wrapper.find(Label).exists()).toBeFalsy()
+    })
+  })
+
+  describe('when the field does specify a legend', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <FieldUneditable type="text" name="testField" legend="testLegend">testValue</FieldUneditable>
+        </Form>,
+      )
+    })
+
+    test('should render the field with a legend', () => {
+      expect(wrapper.find('legend').text()).toEqual('testLegend')
+    })
+  })
+
+  describe('when the field does specify a hint', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <FieldUneditable type="text" name="testField" hint="testHint">testValue</FieldUneditable>
+        </Form>,
+      )
+    })
+
+    test('should render the field with a legend', () => {
+      expect(wrapper.find(HintText).text()).toEqual('testHint')
+    })
+  })
+
+  describe('when the "onChangeClick" callback is defined', () => {
+    const onChangeClickSpy = jest.fn()
+
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <FieldUneditable type="text" name="testField" label="Test value" onChangeClick={onChangeClickSpy}>
+            testValue
+          </FieldUneditable>
+        </Form>,
+      )
+    })
+
+    test('should render a button to change the field value', () => {
+      expect(wrapper.find(ButtonLink).text()).toEqual('Change Test value')
+    })
+
+    describe('when the "Change" button is clicked', () => {
+      beforeAll(() => {
+        wrapper.find(ButtonLink).simulate('click')
+      })
+
+      test('should call callback defined in the "onChangeClick" prop', () => {
+        expect(onChangeClickSpy).toBeCalledTimes(1)
+      })
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -1955,6 +1955,14 @@
     "@govuk-react/lib" "^0.7.0"
     govuk-colours "^1.0.3"
 
+"@govuk-react/visually-hidden@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@govuk-react/visually-hidden/-/visually-hidden-0.7.1.tgz#a74e980400cc4f2a0766bad8980a4e5d05b1bd21"
+  integrity sha512-Lrc4mJpnpEmmgIBGYPzicq45ty8tF03cjYujMhZyzaEQsYnvZc5Ty2igRvSbYFOJ6KN71wUkQQ0u7c0A4TUZ8A==
+  dependencies:
+    "@govuk-react/lib" "^0.7.1"
+    govuk-colours "^1.0.3"
+
 "@govuk-react/warning-text@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@govuk-react/warning-text/-/warning-text-0.7.0.tgz#67d28d6e8d6bc0b6325cdb6fa084ce3651715c60"


### PR DESCRIPTION
Introduce a new field used to display form values selected in previous form steps.

## Screenshot
![image](https://user-images.githubusercontent.com/4199239/64785554-9123d000-d564-11e9-9417-adcf1ba253a0.png)

Depends on https://github.com/uktrade/data-hub-components/pull/151