### PR TITLE
feat: Add ability to display error message to DeleteCompanyListSection

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@govuk-react/checkbox": "^0.7.1",
     "@govuk-react/constants": "^0.7.1",
     "@govuk-react/details": "^0.7.1",
+    "@govuk-react/error-summary": "^0.7.1",
     "@govuk-react/error-text": "^0.7.1",
     "@govuk-react/form-group": "^0.7.1",
     "@govuk-react/grid-col": "^0.7.1",

--- a/src/company-list/DeleteCompanyListSection.jsx
+++ b/src/company-list/DeleteCompanyListSection.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import { RED } from 'govuk-colours'
 import Button from '@govuk-react/button'
+import ErrorSummary from '@govuk-react/error-summary'
 import InsetText from '@govuk-react/inset-text'
 import Link from '@govuk-react/link'
 import ListItem from '@govuk-react/list-item'
@@ -13,6 +14,7 @@ import FormActions from '../forms/elements/FormActions'
 
 const DeleteCompanyListSection = ({
   companyList,
+  errorMessage,
   onDelete,
   returnUrl,
 }) => {
@@ -20,6 +22,8 @@ const DeleteCompanyListSection = ({
 
   return (
     <div>
+      { errorMessage
+      && <ErrorSummary heading="There was an error deleting this list" description={errorMessage} errors={[]} />}
       <Paragraph>
         Deleting this list will remove all companies from this list. These companies will remain on
         any other lists.
@@ -40,8 +44,13 @@ const DeleteCompanyListSection = ({
 
 DeleteCompanyListSection.propTypes = {
   companyList: PropTypes.object.isRequired,
+  errorMessage: PropTypes.string,
   onDelete: PropTypes.func.isRequired,
   returnUrl: PropTypes.string.isRequired,
+}
+
+DeleteCompanyListSection.defaultProps = {
+  errorMessage: null,
 }
 
 export default DeleteCompanyListSection

--- a/src/company-list/__stories__/DeleteCompanyListSection.stories.jsx
+++ b/src/company-list/__stories__/DeleteCompanyListSection.stories.jsx
@@ -31,3 +31,11 @@ storiesOf('DeleteCompanyListSection', module)
       returnUrl="#"
     />
   ))
+  .add('with error', () => (
+    <DeleteCompanyListSection
+      companyList={listWithMultipleItems}
+      errorMessage="Request failed with status code 404"
+      onDelete={onDelete}
+      returnUrl="#"
+    />
+  ))

--- a/src/company-list/__tests__/DeleteCompanyListSection.test.jsx
+++ b/src/company-list/__tests__/DeleteCompanyListSection.test.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import Button from '@govuk-react/button'
+import ErrorSummary from '@govuk-react/error-summary'
 import ListItem from '@govuk-react/list-item'
 
 import DeleteCompanyListSection from '../DeleteCompanyListSection'
@@ -41,6 +42,29 @@ describe('DeleteCompanyListSection', () => {
     test('triggers the onDelete callback on click', () => {
       wrapper.find(Button).simulate('click')
       expect(onDeleteSpy).toHaveBeenCalledTimes(1)
+    })
+
+    test('does not display an error message by default', () => {
+      expect(wrapper.find(ErrorSummary).exists()).toBeFalsy()
+    })
+  })
+
+  describe('with error message', () => {
+    test('displays the error message', () => {
+      const companyList = {
+        ...baseCompanyList,
+        item_count: 10,
+      }
+      const wrapper = mount(
+        <DeleteCompanyListSection
+          companyList={companyList}
+          onDelete={jest.fn()}
+          returnUrl="test-return-url"
+          errorMessage="Request failed"
+        />,
+      )
+
+      expect(wrapper.find(ErrorSummary).exists()).toBeTruthy()
     })
   })
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1291,6 +1291,22 @@
     govuk-colours "^1.0.3"
     polished "^3.0.3"
 
+"@govuk-react/error-summary@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@govuk-react/error-summary/-/error-summary-0.7.1.tgz#6d09aadf2a1c4b5aaec7d9dead3ea9d39a190e7f"
+  integrity sha512-WdMPi2venNptP42qaHiTt4jOEaJqsxqbINwgcoxJ4sXkiPowXm/dpVNtSDdTM89tQhJDimQfbRHZEsbs7YRC1g==
+  dependencies:
+    "@govuk-react/constants" "^0.7.1"
+    "@govuk-react/heading" "^0.7.1"
+    "@govuk-react/input-field" "^0.7.1"
+    "@govuk-react/lib" "^0.7.1"
+    "@govuk-react/link" "^0.7.1"
+    "@govuk-react/list-item" "^0.7.1"
+    "@govuk-react/paragraph" "^0.7.1"
+    "@govuk-react/text-area" "^0.7.1"
+    "@govuk-react/unordered-list" "^0.7.1"
+    govuk-colours "^1.0.3"
+
 "@govuk-react/error-text@^0.7.1":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@govuk-react/error-text/-/error-text-0.7.1.tgz#0c324cd35a0717a5abf2c335347c44f25331e010"
@@ -1509,6 +1525,19 @@
   dependencies:
     "@govuk-react/constants" "^0.7.1"
     "@govuk-react/lib" "^0.7.1"
+    govuk-colours "^1.0.3"
+
+"@govuk-react/text-area@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@govuk-react/text-area/-/text-area-0.7.1.tgz#61089f4facb4f01c495ad1b2c63dbfeef33911e0"
+  integrity sha512-1GMU0+7FUZJCzAsbMj2gKlYeZONhb6QrUV7Ok+pg8QpRuF1Sbl90cQr8QGDjc/jOARPNUkbtO+2fV8jng1KT5A==
+  dependencies:
+    "@govuk-react/constants" "^0.7.1"
+    "@govuk-react/error-text" "^0.7.1"
+    "@govuk-react/hint-text" "^0.7.1"
+    "@govuk-react/hoc" "^0.7.1"
+    "@govuk-react/label" "^0.7.1"
+    "@govuk-react/label-text" "^0.7.1"
     govuk-colours "^1.0.3"
 
 "@govuk-react/unordered-list@^0.7.1":


### PR DESCRIPTION
If the XHR request to delete the company list fails, then we need to do something useful. This adds a way to display an error message to the user when this happens.

## To test

1. Navigate to DeleteCompanyListSection in Storybook.
1. Have a look at the different stories (a new 'with error' story has been added).

## Screenshot

![image](https://user-images.githubusercontent.com/12693549/64945129-d64b4900-d867-11e9-8fd8-c7bda6cded2a.png)
