### PR TITLE
refactor: Remove use of uniqueId for key

### DIFF
--- a/src/activity-feed/cards/CompaniesHouseCompany.jsx
+++ b/src/activity-feed/cards/CompaniesHouseCompany.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { get, uniqueId } from 'lodash'
+import { get } from 'lodash'
 
 import PropTypes from 'prop-types'
 import {
@@ -47,11 +47,10 @@ export default class CompaniesHouseCompany extends React.PureComponent {
     const returnsLastMadeUpDate = DateUtils.format(get(activity, 'object.dit:returnsLastMadeUpDate'))
     const returnsNextDueDate = DateUtils.format(get(activity, 'object.dit:returnsNextDueDate'))
     const sicCodes = get(activity, 'object.dit:sicCodes')
-    const sicCodesCollection = sicCodes.map((value, index) => {
-      const id = uniqueId(`id-${index}`)
+    const sicCodesCollection = sicCodes.map((value) => {
       return {
-        id,
         value,
+        id: value,
       }
     })
 

--- a/src/activity-feed/cards/HmrcExporter.jsx
+++ b/src/activity-feed/cards/HmrcExporter.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { get, uniqueId } from 'lodash'
+import { get } from 'lodash'
 
 import PropTypes from 'prop-types'
 import {
@@ -36,11 +36,10 @@ export default class HmrcExporter extends React.PureComponent {
     const reference = get(activity, 'object.attributedTo.name')
     const summary = get(activity, 'summary')
     const exportItemCodes = get(activity, 'object.dit:exportItemCodes')
-    const exportItemCodesCollection = exportItemCodes.map((value, index) => {
-      const id = uniqueId(`id-${index}`)
+    const exportItemCodesCollection = exportItemCodes.map((value) => {
       return {
-        id,
         value,
+        id: value,
       }
     })
 

--- a/src/entity-search/EntityList.jsx
+++ b/src/entity-search/EntityList.jsx
@@ -2,7 +2,6 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { SPACING } from '@govuk-react/constants'
-import { uniqueId } from 'lodash'
 
 import EntityListItem from './EntityListItem'
 
@@ -20,7 +19,7 @@ const EntityList = ({ entities, onEntityClick }) => {
     <StyledEntityList>
       {entities.map((entity) => {
         return (
-          <StyledEntityListItem key={uniqueId()}>
+          <StyledEntityListItem key={`entity-list-item_${entity.id}`}>
             <EntityListItem onEntityClick={onEntityClick} {...entity} />
           </StyledEntityListItem>
         )

--- a/src/entity-search/EntityListItem.jsx
+++ b/src/entity-search/EntityListItem.jsx
@@ -1,4 +1,3 @@
-import { uniqueId } from 'lodash'
 import React from 'react'
 import styled from 'styled-components'
 import { FONT_SIZE, MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
@@ -43,10 +42,18 @@ const StyledInsetText = styled(InsetText)`
   }
 `
 
-const EntityListItem = ({ canHandleClick, onEntityClick, data, text, heading, meta }) => {
+const EntityListItem = ({
+  id,
+  canHandleClick,
+  onEntityClick,
+  data,
+  text,
+  heading,
+  meta,
+}) => {
   return (
     <StyledEntity
-      key={uniqueId()}
+      key={`entity_${id}`}
       onClick={() => (canHandleClick ? onEntityClick(data) : null)}
       canHandleClick={canHandleClick}
     >
@@ -60,6 +67,7 @@ const EntityListItem = ({ canHandleClick, onEntityClick, data, text, heading, me
 }
 
 EntityListItem.propTypes = {
+  id: PropTypes.string.isRequired,
   onEntityClick: PropTypes.func.isRequired,
   data: PropTypes.object.isRequired,
   canHandleClick: PropTypes.bool.isRequired,

--- a/src/entity-search/EntityListItemMetaList.jsx
+++ b/src/entity-search/EntityListItemMetaList.jsx
@@ -1,4 +1,3 @@
-import { uniqueId } from 'lodash'
 import React from 'react'
 import styled from 'styled-components'
 import { FONT_SIZE, SPACING } from '@govuk-react/constants'
@@ -19,7 +18,7 @@ const StyledMetaItem = styled('div')`
 const EntityListItemMetaList = ({ meta }) => {
   return (
     Object.keys(meta).map(metaKey => (
-      <StyledMetaItem key={uniqueId()}>
+      <StyledMetaItem key={metaKey}>
         <span>{metaKey}:</span>
         <span>{meta[metaKey]}</span>
       </StyledMetaItem>

--- a/src/entity-search/__tests__/__snapshots__/useDnbSearch.test.jsx.snap
+++ b/src/entity-search/__tests__/__snapshots__/useDnbSearch.test.jsx.snap
@@ -47,6 +47,7 @@ Array [
       },
     },
     "heading": "Some other company",
+    "id": "219999999",
     "meta": Object {
       "Address": "123 ABC Road, Brighton, BN2 9QB",
     },
@@ -112,6 +113,7 @@ Array [
       },
     },
     "heading": "Some company name",
+    "id": "12345678",
     "meta": Object {
       "Address": "123 Fake Street, Brighton, BN1 4SE",
     },
@@ -174,6 +176,7 @@ Array [
       },
     },
     "heading": "Some other company",
+    "id": "219999999",
     "meta": Object {
       "Address": "123 ABC Road, Brighton, BN2 9QB",
     },
@@ -238,6 +241,7 @@ Object {
     },
   },
   "heading": "Some company name",
+  "id": "12345678",
   "meta": Object {
     "Address": "123 Fake Street, Brighton, BN1 4SE",
   },

--- a/src/entity-search/useDnbSearch.jsx
+++ b/src/entity-search/useDnbSearch.jsx
@@ -10,6 +10,7 @@ function useDnbSearch(apiEndpoint) {
     const { dnb_company, datahub_company } = record
 
     return {
+      id: dnb_company.duns_number,
       heading: dnb_company.primary_name,
       meta: {
         Address: compact([


### PR DESCRIPTION
## Description of change
Using `uniqueId` is bad practice as it regenerates the `key` for each render which leads to performance issues.