### PR TITLE
fix: Set limit on the company name filter in FieldDnbCompany

### DIFF
--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -70,6 +70,7 @@ const FieldDnbCompany = ({
           name="dnbCompanyName"
           type="search"
           required="Enter company name"
+          maxLength={30}
         />
 
         <FieldInput

--- a/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
+++ b/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
@@ -81,6 +81,10 @@ describe('FieldDnbCompany', () => {
         .toEqual('Company name')
     })
 
+    test('should limit the number of characters in the company name filter to 30', () => {
+      expect(wrapper.find(FieldInput).at(0).prop('maxLength')).toEqual(30)
+    })
+
     test('should render the company postcode filter', () => {
       expect(wrapper.find(FieldInput).at(1).text())
         .toEqual('Company postcode (optional)')

--- a/src/forms/elements/__tests__/FieldInput.test.jsx
+++ b/src/forms/elements/__tests__/FieldInput.test.jsx
@@ -8,6 +8,26 @@ import FieldInput from '../FieldInput'
 describe('FieldInput', () => {
   let wrapper
 
+  describe('when the field is mounted', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <FieldInput type="text" name="testField" />
+        </Form>,
+      )
+    })
+
+    test('should set default attributes on the input', () => {
+      const input = wrapper.find('input[type="text"]')
+      expect(input.prop('id')).toEqual('testField')
+      expect(input.prop('name')).toEqual('testField')
+      expect(input.prop('type')).toEqual('text')
+      expect(input.prop('value')).toEqual('')
+      expect(input.prop('onBlur')).toBeInstanceOf(Function)
+      expect(input.prop('onChange')).toBeInstanceOf(Function)
+    })
+  })
+
   describe('when the field does specify a label', () => {
     beforeAll(() => {
       wrapper = mount(
@@ -107,6 +127,22 @@ describe('FieldInput', () => {
 
     test('should update value in form state', () => {
       expect(wrapper.find('#values').text()).toEqual('testValue')
+    })
+  })
+
+  describe('when extra props are passed to the component', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <FieldInput type="text" name="testField" minLength={3} maxLength={10} />
+        </Form>,
+      )
+    })
+
+    test('should render input with all the extra props', () => {
+      const input = wrapper.find('input[type="text"]')
+      expect(input.prop('minLength')).toEqual(3)
+      expect(input.prop('maxLength')).toEqual(10)
     })
   })
 })

--- a/src/forms/hooks/__tests__/useForm.test.jsx
+++ b/src/forms/hooks/__tests__/useForm.test.jsx
@@ -508,23 +508,6 @@ describe('useForm', () => {
     })
   })
 
-  describe('when setIsSubmitted() is called', () => {
-    const { result } = renderHook(() => useForm())
-    let error
-
-    act(() => {
-      try {
-        result.current.goForward()
-      } catch (e) {
-        error = e
-      }
-    })
-
-    test('should not throw an error', () => {
-      expect(error).toBeUndefined()
-    })
-  })
-
   describe('when setIsSubmitted() is called with a "true" value', () => {
     const { result } = renderHook(() => useForm())
 


### PR DESCRIPTION
https://trello.com/c/WxE5JdB3/334-character-limit-on-company-name-search-field-should-be-enforced

Required due to limitation of the DnB service.