### PR TITLE
fix: Unset field value if empty string

### DIFF
--- a/src/forms/hooks/__tests__/useForm.test.jsx
+++ b/src/forms/hooks/__tests__/useForm.test.jsx
@@ -195,20 +195,38 @@ describe('useForm', () => {
   })
 
   describe('when setFieldValue() is called', () => {
-    const { result } = renderHook(() => useForm())
+    describe('when field value is populated', () => {
+      const { result } = renderHook(() => useForm())
 
-    act(() => {
-      result.current.setFieldValue('testField', 'testValue')
-    })
+      act(() => {
+        result.current.setFieldValue('testField', 'testValue')
+      })
 
-    test('should set field value', () => {
-      expect(result.current.values).toEqual({
-        testField: 'testValue',
+      test('should set the field value', () => {
+        expect(result.current.values).toEqual({
+          testField: 'testValue',
+        })
+      })
+
+      test('should set "isDirty" to true', () => {
+        expect(result.current.isDirty).toBeTruthy()
       })
     })
 
-    test('should set "isDirty" to false', () => {
-      expect(result.current.isDirty).toBeTruthy()
+    describe('when field value is an empty string', () => {
+      const { result } = renderHook(() => useForm())
+
+      act(() => {
+        result.current.setFieldValue('testField', '')
+      })
+
+      test('should unset the field value', () => {
+        expect(result.current.values).toEqual({})
+      })
+
+      test('should set "isDirty" to false', () => {
+        expect(result.current.isDirty).toBeFalsy()
+      })
     })
   })
 

--- a/src/forms/hooks/useForm.js
+++ b/src/forms/hooks/useForm.js
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { isEmpty } from 'lodash'
+import { isEmpty, omit } from 'lodash'
 import { useBeforeUnload } from 'react-use'
 
 function useForm({
@@ -74,6 +74,10 @@ function useForm({
   }
 
   const setFieldValue = (name, fieldValue) => setValues((prevValues) => {
+    if (fieldValue === '') {
+      return omit(prevValues, name)
+    }
+
     return { ...prevValues, [name]: fieldValue }
   })
   const setFieldTouched = (name, fieldTouched) => {


### PR DESCRIPTION
## Description of change
When typing a field the `values` are set. When deleting the entered text, the field updates but when there is no text it is set to an empty string. Rather than setting to an empty string, the field should be unset.

This became apparent in a bug with D&B company search when the post code was entered, then a user deleted it. An empty string was sent to the API which was invalid and then return a `400`.

## Test instructions
Use any of the form stories in Storybook, enter a value in the field and observe the `values` field to see how it changes.