### PR TITLE
fix: Replace InputField with Input component to remove extra label tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@govuk-react/heading": "^0.7.1",
     "@govuk-react/hint-text": "^0.7.1",
     "@govuk-react/icons": "^0.7.1",
+    "@govuk-react/input": "^0.7.1",
     "@govuk-react/input-field": "^0.7.1",
     "@govuk-react/inset-text": "^0.7.1",
     "@govuk-react/label": "^0.7.1",

--- a/src/company-lists/__tests__/CreateListForm.test.jsx
+++ b/src/company-lists/__tests__/CreateListForm.test.jsx
@@ -1,5 +1,8 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import HintText from '@govuk-react/hint-text'
+import ErrorText from '@govuk-react/error-text'
+
 import CreateListForm from '../CreateListForm'
 
 describe('CreateListForm', () => {
@@ -19,6 +22,7 @@ describe('CreateListForm', () => {
     const hint = wrapper.find('span').at(0)
     const button = wrapper.find('button')
     const cancelUrl = wrapper.find('a[href="/companies/"]')
+
     test('should render correctly', () => {
       expect(label.text()).toEqual('List name')
       expect(hint.text()).toEqual('Hint')
@@ -27,6 +31,7 @@ describe('CreateListForm', () => {
       expect(cancelUrl).toHaveLength(1)
     })
   })
+
   describe('When not passing props that are not required', () => {
     const wrapper = mount(
       <CreateListForm
@@ -37,13 +42,15 @@ describe('CreateListForm', () => {
         maxLength={30}
       />,
     )
-    const hint = wrapper.find('span').at(0)
+    const hint = wrapper.find(HintText)
     const cancelUrl = wrapper.find('a[href="/companies/"]')
+
     test('should render correctly', () => {
-      expect(hint.text()).toEqual('')
+      expect(hint.exists()).toBeFalsy()
       expect(cancelUrl).toHaveLength(1)
     })
   })
+
   describe('when submitting with no errors', () => {
     const onSubmitSpy = jest.fn()
     const wrapper = mount(
@@ -55,6 +62,7 @@ describe('CreateListForm', () => {
         maxLength={30}
       />,
     )
+
     test('should fire a onSubmit handler', () => {
       const input = wrapper.find('input')
       input.simulate('change', { target: { value: 'list name' } })
@@ -62,6 +70,7 @@ describe('CreateListForm', () => {
       expect(onSubmitSpy).toBeCalledTimes(1)
     })
   })
+
   describe('when submitting form with errors', () => {
     const onSubmitSpy = jest.fn()
     const wrapper = mount(
@@ -73,19 +82,19 @@ describe('CreateListForm', () => {
         maxLength={30}
       />,
     )
+
     test('should prompt for a list name', () => {
       wrapper.simulate('submit')
-      const errorMessage = wrapper.find('span').at(1)
       expect(onSubmitSpy).toBeCalledTimes(0)
-      expect(errorMessage.text()).toContain('Enter a name for your list')
+      expect(wrapper.find(ErrorText).text()).toEqual('Enter a name for your list')
     })
+
     test('should ask for less than 30 characters', () => {
       const input = wrapper.find('input')
       input.simulate('change', { target: { value: 'oneverylooooooooooooooooooooooooooooooooooooonnnnnngggg name' } })
       wrapper.simulate('submit')
-      const errorMessage = wrapper.find('span').at(1)
       expect(onSubmitSpy).toBeCalledTimes(0)
-      expect(errorMessage.text()).toContain('Enter list name which is no longer than 30 characters')
+      expect(wrapper.find(ErrorText).text()).toEqual('Enter list name which is no longer than 30 characters')
     })
   })
 })

--- a/src/forms/elements/FieldInput.jsx
+++ b/src/forms/elements/FieldInput.jsx
@@ -1,28 +1,42 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import InputField from '@govuk-react/input-field'
+import styled from 'styled-components'
+
+import Input from '@govuk-react/input'
+import ErrorText from '@govuk-react/error-text'
+import { BORDER_WIDTH_FORM_ELEMENT_ERROR, SPACING } from '@govuk-react/constants'
+import { ERROR_COLOUR } from 'govuk-colours'
 
 import useField from '../hooks/useField'
 import FieldWrapper from './FieldWrapper'
+
+const StyledInputWrapper = styled('div')`
+  ${props => props.error && `
+    border-left: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+    margin-right: ${SPACING.SCALE_3};
+    padding-left: ${SPACING.SCALE_2};
+  `}
+`
 
 const FieldInput = ({ name, type, validate, required, label, legend, hint, ...rest }) => {
   const { value, error, touched, onChange, onBlur } = useField({ name, validate, required })
 
   return (
     <FieldWrapper {...({ name, label, legend, hint, error })}>
-      <InputField
-        key={name}
-        meta={{ error, touched }}
-        input={{
-          id: name,
-          type,
-          name,
-          value,
-          onChange,
-          onBlur,
-          ...rest,
-        }}
-      />
+      <StyledInputWrapper error={error}>
+        {touched && error && <ErrorText>{error}</ErrorText>}
+        <Input
+          key={name}
+          error={touched && error}
+          id={name}
+          type={type}
+          name={name}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          {...rest}
+        />
+      </StyledInputWrapper>
     </FieldWrapper>
   )
 }

--- a/src/forms/elements/__tests__/FieldInput.test.jsx
+++ b/src/forms/elements/__tests__/FieldInput.test.jsx
@@ -1,6 +1,8 @@
 import React from 'react'
 import { mount } from 'enzyme'
 import HintText from '@govuk-react/hint-text'
+import Label from '@govuk-react/label'
+import ErrorText from '@govuk-react/error-text'
 
 import Form from '../Form'
 import FieldInput from '../FieldInput'
@@ -42,7 +44,7 @@ describe('FieldInput', () => {
     })
 
     test('should render the field with a label', () => {
-      expect(wrapper.find('label').exists()).toBeTruthy()
+      expect(wrapper.find(Label).exists()).toBeTruthy()
     })
   })
 
@@ -56,8 +58,7 @@ describe('FieldInput', () => {
     })
 
     test('should render the field without a label', () => {
-      const label = wrapper.find('span')
-      expect(label.text()).toEqual('')
+      expect(wrapper.find(Label).exists()).toBeFalsy()
     })
   })
 
@@ -100,8 +101,11 @@ describe('FieldInput', () => {
     })
 
     test('should render with an error', () => {
-      const errorContainer = wrapper.find('span').at(1)
-      expect(errorContainer.text()).toEqual('testError')
+      const inputWrapper = wrapper.find('div').at(1)
+      expect(wrapper.find(ErrorText).text()).toEqual('testError')
+      expect(inputWrapper).toHaveStyleRule('border-left', '4px solid #b10e1e')
+      expect(inputWrapper).toHaveStyleRule('margin-right', '15px')
+      expect(inputWrapper).toHaveStyleRule('padding-left', '10px')
     })
   })
 


### PR DESCRIPTION
This PR is removing the additional `label` tag added by`InputField` component.

No visual changes.