### PR TITLE
fix: Require two or more characters when searching for D&B companies

### DIFF
--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -70,6 +70,9 @@ const FieldDnbCompany = ({
           name="dnbCompanyName"
           type="search"
           required="Enter company name"
+          validate={value => (value && value.length < 2
+            ? 'Enter company name that is 2 characters long or more'
+            : null)}
           maxLength={30}
         />
 

--- a/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
+++ b/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
@@ -143,6 +143,25 @@ describe('FieldDnbCompany', () => {
     })
   })
 
+  describe('when the search button is clicked with company name shorter than the minimum of 2 characters', () => {
+    beforeAll(async () => {
+      wrapper = wrapFieldDnbCompanyForm()
+
+      wrapper.find('input[name="dnbCompanyName"]')
+        .simulate('change', { target: { value: 'a' } })
+
+      wrapper.find(FormActions).find('button').simulate('click')
+
+      await act(flushPromises)
+
+      wrapper.update()
+    })
+
+    test('should show an error', () => {
+      expect(wrapper.text()).toContain('Enter company name that is 2 characters long or more')
+    })
+  })
+
   describe('when the search button is clicked after filling the company name field', () => {
     beforeAll(async () => {
       setupSuccessMocks(API_ENDPOINT)


### PR DESCRIPTION
D&B service has a requirement of minimum two characters in the search term, this PR is adding a validation rule respecting that limit.