### PR TITLE
feat: Allow for custom components as back and forward buttons in forms

### DIFF
--- a/src/forms/elements/Step.jsx
+++ b/src/forms/elements/Step.jsx
@@ -6,10 +6,7 @@ import useFormContext from '../hooks/useFormContext'
 import ButtonLink from '../../button-link/ButtonLink'
 import FormActions from './FormActions'
 
-function Step({
-  name, backButtonText, forwardButtonText,
-  hideBackButton, hideForwardButton, children,
-}) {
+function Step({ name, backButton, forwardButton, children }) {
   const {
     currentStep,
     goBack,
@@ -31,41 +28,53 @@ function Step({
     return null
   }
 
-  const defaultBackButtonText = 'Back'
-  const defaultForwardButtonText = isLastStep() ? 'Submit' : 'Continue'
+  const renderBackButton = () => {
+    if (typeof backButton === 'undefined') {
+      return <ButtonLink name="back" onClick={goBack}>Back</ButtonLink>
+    }
+
+    if (typeof backButton === 'string') {
+      return <ButtonLink name="back" onClick={goBack}>{backButton}</ButtonLink>
+    }
+
+    return backButton
+  }
+
+  const renderForwardButton = () => {
+    if (typeof forwardButton === 'undefined') {
+      return <Button name="forward">{isLastStep() ? 'Submit' : 'Continue'}</Button>
+    }
+
+    if (typeof forwardButton === 'string') {
+      return <Button name="forward">{forwardButton}</Button>
+    }
+
+    return forwardButton
+  }
 
   return (
     <>
       {children}
 
       <FormActions>
-        {!hideForwardButton && <Button>{forwardButtonText || defaultForwardButtonText}</Button>}
+        {renderForwardButton()}
 
-        {!hideBackButton && !isFirstStep() && (
-          <ButtonLink onClick={goBack}>
-            {backButtonText || defaultBackButtonText}
-          </ButtonLink>
-        )}
+        {!isFirstStep() && renderBackButton()}
       </FormActions>
     </>
   )
 }
 
 Step.propTypes = {
-  name: PropTypes.string,
-  backButtonText: PropTypes.string,
-  forwardButtonText: PropTypes.string,
-  hideBackButton: PropTypes.bool,
-  hideForwardButton: PropTypes.bool,
+  name: PropTypes.string.isRequired,
+  backButton: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  forwardButton: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   children: PropTypes.node,
 }
 
 Step.defaultProps = {
-  name: null,
-  backButtonText: null,
-  forwardButtonText: null,
-  hideBackButton: false,
-  hideForwardButton: false,
+  backButton: undefined,
+  forwardButton: undefined,
   children: null,
 }
 

--- a/src/forms/elements/__stories__/FieldDnbCompany.stories.jsx
+++ b/src/forms/elements/__stories__/FieldDnbCompany.stories.jsx
@@ -32,7 +32,7 @@ storiesOf('Forms', module)
       <Form onSubmit={action('onSubmit')}>
         {({ values }) => (
           <>
-            <Step name="first" hideForwardButton={true}>
+            <Step name="first" forwardButton={null}>
               <FieldDnbCompany
                 name="dnb_company"
                 legend={<H3>Find the company</H3>}
@@ -66,7 +66,7 @@ storiesOf('Forms', module)
     return (
       <Form onSubmit={action('onSubmit')}>
         <>
-          <Step name="first" hideForwardButton={true}>
+          <Step name="first" forwardButton={null}>
             <FieldDnbCompany
               name="dnb_company"
               legend={<H3>Find the company</H3>}
@@ -86,7 +86,7 @@ storiesOf('Forms', module)
     return (
       <Form onSubmit={action('onSubmit')}>
         <>
-          <Step name="first" hideForwardButton={true}>
+          <Step name="first" forwardButton={null}>
             <FieldDnbCompany
               name="dnb_company"
               legend={<H3>Find the company</H3>}

--- a/src/forms/elements/__stories__/Form.stories.jsx
+++ b/src/forms/elements/__stories__/Form.stories.jsx
@@ -71,7 +71,7 @@ storiesOf('Forms', module)
               </Step>
             )}
 
-            <Step name="third" hideForwardButton={true} hideBackButton={true}>
+            <Step name="third" forwardButton={null} backButton={null}>
               <FieldDnbCompany
                 name="dnb_company"
                 legend={<H3>Find the company</H3>}

--- a/src/forms/elements/__stories__/Step.stories.jsx
+++ b/src/forms/elements/__stories__/Step.stories.jsx
@@ -36,7 +36,7 @@ storiesOf('Forms', module)
           <Values />
         </Step>
 
-        <Step name="second" forwardButtonText="GO FORWARD!" backButtonText="GO BACK!">
+        <Step name="second" forwardButton="GO FORWARD!" backButton="GO BACK!">
           <Values />
 
           <p>Custom button labels <span role="img">⬇</span>️</p>

--- a/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
+++ b/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
@@ -39,7 +39,7 @@ const wrapFieldDnbCompanyForm = () => {
 
           <Step name="first" />
 
-          <Step name="second" hideBackButton={true} hideForwardButton={true}>
+          <Step name="second" backButton={null} forwardButton={null}>
             <FieldDnbCompany
               name="testField"
               label="testLabel"

--- a/src/forms/elements/__tests__/Step.test.jsx
+++ b/src/forms/elements/__tests__/Step.test.jsx
@@ -16,7 +16,7 @@ describe('Step', () => {
   let formState
   let wrapper
 
-  describe('when there is a form with one step', () => {
+  describe('when there is a form with only one step', () => {
     const onSubmitSpy = jest.fn()
 
     beforeAll(() => {
@@ -37,25 +37,23 @@ describe('Step', () => {
 
     afterEach(() => onSubmitSpy.mockReset())
 
-    describe('when the step is mounted', () => {
-      test('should render only a "Submit" button', () => {
-        expect(wrapper.find('button').text()).toEqual('Submit')
-      })
-      test('should save the current step to form state', () => {
-        expect(formState.currentStep).toEqual(0)
-      })
-      test('should register the step', () => {
-        expect(formState.steps).toEqual(['testStep1'])
-      })
-      test('should render child fields', () => {
-        expect(wrapper.find('#testField1').exists()).toBeTruthy()
-      })
-      test('should register fields within the step', () => {
-        expect(Object.keys(formState.fields)).toEqual(['testField1'])
-      })
+    test('should render only a "Submit" button', () => {
+      expect(wrapper.find('button').text()).toEqual('Submit')
+    })
+    test('should save the current step to form state', () => {
+      expect(formState.currentStep).toEqual(0)
+    })
+    test('should register the step', () => {
+      expect(formState.steps).toEqual(['testStep1'])
+    })
+    test('should render child fields', () => {
+      expect(wrapper.find('#testField1').exists()).toBeTruthy()
+    })
+    test('should register fields within the step', () => {
+      expect(Object.keys(formState.fields)).toEqual(['testField1'])
     })
 
-    describe('when the form is filled and "Submit" button is clicked', () => {
+    describe('when the form is filled and the "Submit" button is clicked', () => {
       beforeAll(() => {
         const testField1 = wrapper.find('#testField1')
         testField1.simulate('change', { target: { value: 'testValue' } })
@@ -94,43 +92,20 @@ describe('Step', () => {
       formState = JSON.parse(wrapper.find('.form-state').text())
     })
 
-    describe('when the form is mounted', () => {
-      beforeAll(() => {
-        wrapper = mount(
-          <Form>
-            {form => (
-              <>
-                <div className="form-state">{JSON.stringify(form)}</div>
-                <Step name="testStepMounted">
-                  <TestField type="text" name="testField1" id="testField1" />
-                </Step>
-                {form.values.testField1 === 'mount' && (
-                  <Step name="testStepWillMount">
-                    <TestField type="text" name="testField2" id="testField2" />
-                  </Step>
-                )}
-              </>
-            )}
-          </Form>,
-        )
-        formState = JSON.parse(wrapper.find('.form-state').text())
-      })
-
-      test('should render only a "Submit" button', () => {
-        expect(wrapper.find('button').text()).toEqual('Submit')
-      })
-      test('should save the current step to form state', () => {
-        expect(formState.currentStep).toEqual(0)
-      })
-      test('should register the step', () => {
-        expect(formState.steps).toEqual(['testStepMounted'])
-      })
-      test('should render child fields', () => {
-        expect(wrapper.find('#testField1').exists()).toBeTruthy()
-      })
-      test('should register fields within the step', () => {
-        expect(Object.keys(formState.fields)).toEqual(['testField1'])
-      })
+    test('should render only a "Submit" button', () => {
+      expect(wrapper.find('button').text()).toEqual('Submit')
+    })
+    test('should save the current step to form state', () => {
+      expect(formState.currentStep).toEqual(0)
+    })
+    test('should register the step', () => {
+      expect(formState.steps).toEqual(['testStepMounted'])
+    })
+    test('should render child fields', () => {
+      expect(wrapper.find('#testField1').exists()).toBeTruthy()
+    })
+    test('should register fields within the step', () => {
+      expect(Object.keys(formState.fields)).toEqual(['testField1'])
     })
 
     describe('when the hidden step is mounted', () => {
@@ -183,156 +158,225 @@ describe('Step', () => {
       formState = JSON.parse(wrapper.find('.form-state').text())
     })
 
-    describe('when the form is mounted', () => {
-      test('should render only a "Continue" button', () => {
-        expect(wrapper.find('button').text()).toEqual('Continue')
+    test('should render only a "Continue" button', () => {
+      expect(wrapper.find('button').text()).toEqual('Continue')
+    })
+    test('should save the current step to form state', () => {
+      expect(formState.currentStep).toEqual(0)
+    })
+    test('should render child fields from the first step', () => {
+      expect(wrapper.find('#testField1').exists()).toBeTruthy()
+    })
+    test('should register fields from the first step', () => {
+      expect(Object.keys(formState.fields)).toEqual(['testField1'])
+    })
+    test('should register all steps', () => {
+      expect(formState.steps).toEqual([
+        'testStep1',
+        'testStep2',
+        'testStep3',
+        'testStep4',
+      ])
+    })
+
+    describe('when the required field is not filled and the "Continue" button is clicked', () => {
+      beforeAll(() => {
+        wrapper.find('button').simulate('submit')
+        formState = JSON.parse(wrapper.find('.form-state').text())
       })
-      test('should save the current step to form state', () => {
+
+      test('should stay on the same step', () => {
         expect(formState.currentStep).toEqual(0)
       })
+      test('should store errors in the form state', () => {
+        expect(formState.errors).toEqual({
+          testField1: 'testField1 is required',
+        })
+      })
+      test('should mark all fields as touched and store this info in the form state', () => {
+        expect(formState.touched).toEqual({
+          testField1: true,
+        })
+      })
       test('should render child fields from the first step', () => {
-        expect(wrapper.find('#testField1').exists()).toBeTruthy()
+        expect(wrapper.find('#testField2').exists()).toBeFalsy()
       })
       test('should register fields from the first step', () => {
         expect(Object.keys(formState.fields)).toEqual(['testField1'])
       })
-      test('should register all steps', () => {
-        expect(formState.steps).toEqual([
-          'testStep1',
-          'testStep2',
-          'testStep3',
-          'testStep4',
-        ])
+    })
+
+    describe('when the required field is filled and the "Continue" button is clicked', () => {
+      beforeAll(() => {
+        wrapper.find('#testField1').simulate('change', { target: { value: 'hello' } })
+        wrapper.find('button').simulate('submit')
+        formState = JSON.parse(wrapper.find('.form-state').text())
       })
 
-      describe('when the required field is not filled and the "Continue" button is clicked', () => {
+      test('should change the current step and save it to form state', () => {
+        expect(formState.currentStep).toEqual(1)
+      })
+      test('should render a "Continue" button', () => {
+        expect(wrapper.find('button[name="forward"]').text()).toEqual('Continue')
+      })
+      test('should render a "Back" button', () => {
+        expect(wrapper.find('button[name="back"]').text()).toEqual('Back')
+      })
+      test('should render child fields from the second step', () => {
+        expect(wrapper.find('#testField2').exists()).toBeTruthy()
+      })
+      test('should not render child fields from the first step', () => {
+        expect(wrapper.find('#testField1').exists()).toBeFalsy()
+      })
+      test('should register fields from the second step', () => {
+        expect(Object.keys(formState.fields)).toEqual(['testField2'])
+      })
+
+      describe('when the "Back" button is clicked', () => {
         beforeAll(() => {
-          wrapper.find('button').simulate('submit')
+          const prevButton = wrapper.find('button[name="back"]')
+          prevButton.simulate('click')
           formState = JSON.parse(wrapper.find('.form-state').text())
         })
 
-        test('should stay on the same step', () => {
+        test('should change the current step and save it to form state', () => {
           expect(formState.currentStep).toEqual(0)
         })
-        test('should store errors in the form state', () => {
-          expect(formState.errors).toEqual({
-            testField1: 'testField1 is required',
-          })
-        })
-        test('should store which field were touched in the form state', () => {
-          expect(formState.touched).toEqual({
-            testField1: true,
-          })
+        test('should render only the "Continue" button', () => {
+          expect(wrapper.find('button').text()).toEqual('Continue')
         })
         test('should render child fields from the first step', () => {
+          expect(wrapper.find('#testField1').exists()).toBeTruthy()
+        })
+        test('should not render child fields from the second step', () => {
           expect(wrapper.find('#testField2').exists()).toBeFalsy()
         })
         test('should register fields from the first step', () => {
           expect(Object.keys(formState.fields)).toEqual(['testField1'])
         })
       })
-
-      describe('when the required field is filled and the "Continue" button is clicked', () => {
-        beforeAll(() => {
-          wrapper.find('#testField1').simulate('change', { target: { value: 'hello' } })
-          wrapper.find('button').simulate('submit')
-          formState = JSON.parse(wrapper.find('.form-state').text())
-        })
-
-        test('should change the current step and save it to form state', () => {
-          expect(formState.currentStep).toEqual(1)
-        })
-        test('should render child fields from the second step', () => {
-          expect(wrapper.find('#testField2').exists()).toBeTruthy()
-        })
-        test('should not render child fields from the first step', () => {
-          expect(wrapper.find('#testField1').exists()).toBeFalsy()
-        })
-        test('should register fields from the second step', () => {
-          expect(Object.keys(formState.fields)).toEqual(['testField2'])
-        })
-
-        describe('when the "Back" button is clicked', () => {
-          beforeAll(() => {
-            const prevButton = wrapper.find('button').at(1)
-            prevButton.simulate('click')
-            formState = JSON.parse(wrapper.find('.form-state').text())
-          })
-
-          test('should change the current step and save it to form state', () => {
-            expect(formState.currentStep).toEqual(0)
-          })
-          test('should render child fields from the first step', () => {
-            expect(wrapper.find('#testField1').exists()).toBeTruthy()
-          })
-          test('should not render child fields from the second step', () => {
-            expect(wrapper.find('#testField2').exists()).toBeFalsy()
-          })
-          test('should register fields from the first step', () => {
-            expect(Object.keys(formState.fields)).toEqual(['testField1'])
-          })
-        })
-      })
     })
   })
 
-  describe('when the testForwardButtonText prop is passed', () => {
+  describe('when the "forwardButton" prop is passed as a string', () => {
     beforeAll(() => {
       wrapper = mount(
         <Form>
-          <Step name="testStep1" forwardButtonText="testForwardButtonText" />
+          <Step name="testStep1" forwardButton="testForwardButtonText" />
           <Step name="testStep2" />
         </Form>,
       )
     })
 
-    test('should render a back button with modified step', () => {
-      expect(wrapper.find('button').text()).toEqual('testForwardButtonText')
+    test('should render a forward button with a custom text', () => {
+      expect(wrapper.find('button[name="forward"]').text()).toEqual('testForwardButtonText')
     })
   })
 
-  describe('when the backButtonText prop is passed', () => {
+  describe('when the "backButton" prop is passed as a string', () => {
     beforeAll(() => {
       wrapper = mount(
         <Form initialStep={1}>
           <Step name="testStep1" />
-          <Step name="testStep2" backButtonText="testBackButtonText" />
+          <Step name="testStep2" backButton="testBackButtonText" />
         </Form>,
       )
     })
 
-    test('should render a back button with modified step', () => {
-      expect(wrapper.find('button').at(1).text()).toEqual('testBackButtonText')
+    test('should render a back button with a custom text', () => {
+      expect(wrapper.find('button[name="back"]').text()).toEqual('testBackButtonText')
     })
   })
 
-  describe('when the hideForwardButton prop is set to true', () => {
+  describe('when the "forwardButton" prop is passed as "null"', () => {
     beforeAll(() => {
       wrapper = mount(
         <Form>
-          <Step name="testStep1" hideForwardButton={true} />
+          <Step name="testStep1" forwardButton={null} />
           <Step name="testStep2" />
         </Form>,
       )
     })
 
     test('should hide the forward button', () => {
-      expect(wrapper.find('button').exists()).toBeFalsy()
+      expect(wrapper.find('button[name="forward"]').exists()).toBeFalsy()
     })
   })
 
-  describe('when the hideBackButton prop is set to true', () => {
+  describe('when the "backButton" prop is passed as "null"', () => {
     beforeAll(() => {
       wrapper = mount(
         <Form initialStep={1}>
           <Step name="testStep1" />
-          <Step name="testStep2" hideBackButton={true} />
+          <Step name="testStep2" backButton={null} />
         </Form>,
       )
     })
 
     test('should hide the back button', () => {
-      expect(wrapper.find('button').text().includes('Back')).toBeFalsy()
+      expect(wrapper.find('button[name="back"]').exists()).toBeFalsy()
+    })
+  })
+
+  describe('when a component is passed to the "forwardButton" prop', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <Step name="testStep1" forwardButton={<a href="/">Go to form A</a>} />
+          <Step name="testStep2" />
+        </Form>,
+      )
+    })
+
+    test('should render the component', () => {
+      const link = wrapper.find('a')
+      expect(link.text()).toEqual('Go to form A')
+    })
+  })
+
+  describe('when a component is passed to the "backButton" prop', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form initialStep={1}>
+          <Step name="testStep1" />
+          <Step name="testStep2" backButton={<a href="/">Back to homepage</a>} />
+        </Form>,
+      )
+    })
+
+    test('should render the component', () => {
+      const link = wrapper.find('a')
+      expect(link.text()).toEqual('Back to homepage')
+    })
+  })
+
+  describe('when there is a next step and the "forwardButton" prop was not specified', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form>
+          <Step name="testStep1" />
+          <Step name="testStep2" />
+        </Form>,
+      )
+    })
+
+    test('should render the "Continue" button', () => {
+      expect(wrapper.find('button[name="forward"]').text()).toEqual('Continue')
+    })
+  })
+
+  describe('when there is a previous step and the "backButton" prop was not specified', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Form initialStep={1}>
+          <Step name="testStep1" />
+          <Step name="testStep2" />
+        </Form>,
+      )
+    })
+
+    test('should render the "Back" button', () => {
+      expect(wrapper.find('button[name="back"]').text()).toEqual('Back')
     })
   })
 })


### PR DESCRIPTION
**BREAKING CHANGE:** This change is replacing `hideForwardButton`, `hideBackButton`, `forwardButtonText` and `backButtonText` with new `backButton` and `forwardButton` props which now accepts React elements.

**API changes**

`<Step hideForwardButton={true} />` **becomes** `<Step forwardButton={null} />`
`<Step forwardButtonText="Submit form" />` **becomes** `<Step forwardButton="Submit form" />`

New one:
`<Step backButton={<Link href="/companies">Back</Link>} />`