### PR TITLE
Add/remove company to and from lists...

### DIFF
--- a/src/company-lists/AddRemoveFromListForm.jsx
+++ b/src/company-lists/AddRemoveFromListForm.jsx
@@ -1,0 +1,83 @@
+import React from 'react'
+import Button from '@govuk-react/button'
+import Link from '@govuk-react/link'
+import PropTypes from 'prop-types'
+import { GREY_3, TEXT_COLOUR } from 'govuk-colours'
+import LoadingBox from '@govuk-react/loading-box'
+import styled from 'styled-components'
+
+import Form from '../forms/elements/Form'
+import FieldRadios from '../forms/elements/FieldRadios'
+import FieldInput from '../forms/elements/FieldInput'
+import FormActions from '../forms/elements/FormActions'
+
+const StyledDiv = styled.div`
+  margin: 0;
+`
+
+const AddRemoveFromListForm = (
+  {
+    list,
+    onSubmitHandler,
+    createNewListUrl,
+    isLoading,
+    cancelLinkUrl,
+  },
+) => {
+  const { companyId, companyLists } = list
+  const initState = companyLists.reduce((obj, { listId, isAdded }) => {
+    return { ...obj, [listId]: isAdded }
+  }, {})
+  return (
+    <Form initialValues={initState} onSubmit={onSubmitHandler}>
+      <LoadingBox loading={isLoading}>
+        <FieldInput name="company" type="hidden" value={companyId} />
+        {companyLists.map(({ listId, listName }) => (
+          <div key={listId}>
+            <FieldRadios
+              name={listId}
+              legend={`On the "${listName}" list`}
+              options={[
+                {
+                  label: 'Yes',
+                  value: 'yes',
+                  inline: 'true',
+                },
+                {
+                  label: 'No',
+                  value: 'no',
+                  inline: 'true',
+                }]}
+            />
+          </div>
+        ))}
+        <FormActions>
+          <Button
+            as={Link}
+            href={createNewListUrl}
+            buttonColour={GREY_3}
+            buttonTextColour={TEXT_COLOUR}
+          >
+            Create a new list
+          </Button>
+          <StyledDiv>
+            <Button>Save</Button>
+          </StyledDiv>
+        </FormActions>
+        <div>
+          <Link href={cancelLinkUrl}>Cancel</Link>
+        </div>
+      </LoadingBox>
+    </Form>
+  )
+}
+
+AddRemoveFromListForm.propTypes = {
+  onSubmitHandler: PropTypes.func.isRequired,
+  list: PropTypes.object.isRequired,
+  createNewListUrl: PropTypes.string.isRequired,
+  cancelLinkUrl: PropTypes.string.isRequired,
+  isLoading: PropTypes.bool.isRequired,
+}
+
+export default AddRemoveFromListForm

--- a/src/company-lists/__fixtures__/lists-with-company.json
+++ b/src/company-lists/__fixtures__/lists-with-company.json
@@ -1,0 +1,25 @@
+{
+  "companyId": "0fb3379c-341c-4da4-b825-bf8d47b26baa",
+  "companyName": "Lambda plc",
+  "companyLists": [
+    {
+      "listName": "List A",
+      "listId": "63a93bbf-6d1b-4a41-b3f8-975bde0ecacc",
+      "isAdded": "yes",
+      "companyId": "0fb3379c-341c-4da4-b825-bf8d47b26baa"
+    },
+    {
+      "listName": "List B",
+      "listId": "feb862ed-561c-4adb-9d40-dac6d085ff54",
+      "isAdded": "no",
+      "companyId": "0fb3379c-341c-4da4-b825-bf8d47b26baa"
+    },
+    {
+      "listName": "List C",
+      "listId": "45e3883b-f350-4ab6-8695-3c7d037fb14c",
+      "isAdded": "yes",
+      "companyId": "0fb3379c-341c-4da4-b825-bf8d47b26baa"
+    }
+  ]
+}
+

--- a/src/company-lists/__stories__/CompanyLists.stories.jsx
+++ b/src/company-lists/__stories__/CompanyLists.stories.jsx
@@ -1,20 +1,41 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import { action } from '@storybook/addon-actions'
-import { CreateListForm } from '../../index'
-
-const CreateListFormStory = () => {
-  return (
-    <CreateListForm
-      onSubmitHandler={action('I have been clicked!')}
-      name="listName"
-      hint="This is a name only you see, and can be up to 30 characters"
-      label="List name"
-      cancelUrl="/companies/"
-      maxLength={30}
-    />
-  )
-}
+import CreateListForm from '../CreateListForm'
+import AddRemoveFromListForm from '../AddRemoveFromListForm'
+import listsWithCompany from '../__fixtures__/lists-with-company'
 
 storiesOf('Company lists', module)
-  .add('Create a new list', () => <CreateListFormStory />)
+  .add('Create a new list', () => {
+    return (
+      <CreateListForm
+        onSubmitHandler={action('I have been clicked!')}
+        name="listName"
+        hint="This is a name only you see, and can be up to 30 characters"
+        label="List name"
+        cancelUrl="/companies/"
+        maxLength={30}
+      />
+    )
+  })
+  .add('Add or remove from list', () => React.createElement(() => {
+    const [loading, setLoading] = useState(false)
+    const mockRequest = () => {
+      setLoading(true)
+      setTimeout(() => {
+        setLoading(false)
+      }, 2000)
+    }
+    return (
+      <>
+        <h1>Add or remove Lambda plc from your lists</h1>
+        <AddRemoveFromListForm
+          list={listsWithCompany}
+          onSubmitHandler={() => mockRequest()}
+          isLoading={loading}
+          createNewListUrl="#"
+          cancelLinkUrl="#"
+        />
+      </>
+    )
+  }))

--- a/src/company-lists/__tests__/AddRemoveFromList.test.jsx
+++ b/src/company-lists/__tests__/AddRemoveFromList.test.jsx
@@ -1,0 +1,82 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import AddRemoveFromListForm from '../AddRemoveFromListForm'
+import listsWithCompany from '../__fixtures__/lists-with-company'
+
+describe('AddRemoveFromList', () => {
+  describe('When passing props', () => {
+    const wrapper = mount(
+      <AddRemoveFromListForm
+        list={listsWithCompany}
+        onSubmitHandler={() => {}}
+        isLoading={false}
+        createNewListUrl="/create-url"
+        cancelLinkUrl="/cancel-link"
+      />,
+    )
+    const fieldset = wrapper.find('fieldset')
+    const radioButtons = wrapper.find('input[type="radio"]')
+    const legends = wrapper.find('legend')
+    const optionLabels = wrapper.find('fieldset label span')
+    const createNewListLink = wrapper.find('a[href="/create-url"]')
+    const saveButton = wrapper.find('button')
+    const cancelLink = wrapper.find('a[href="/cancel-link"]')
+
+    test('should render a group of radio button options for list A', () => {
+      expect(legends.at(0).text()).toEqual('On the "List A" list')
+      expect(fieldset.at(0)).toHaveLength(1)
+      expect(radioButtons.at(0)).toHaveLength(1)
+      expect(radioButtons.at(1)).toHaveLength(1)
+      expect(optionLabels.at(0).text()).toEqual('Yes')
+      expect(optionLabels.at(1).text()).toEqual('No')
+    })
+
+    test('should render a group of radio button options for list B', () => {
+      expect(legends.at(1).text()).toEqual('On the "List B" list')
+      expect(fieldset.at(1)).toHaveLength(1)
+      expect(radioButtons.at(2)).toHaveLength(1)
+      expect(radioButtons.at(3)).toHaveLength(1)
+      expect(optionLabels.at(2).text()).toEqual('Yes')
+      expect(optionLabels.at(3).text()).toEqual('No')
+    })
+
+    test('should render a group of radio button options for list C', () => {
+      expect(legends.at(2).text()).toEqual('On the "List C" list')
+      expect(fieldset.at(2)).toHaveLength(1)
+      expect(radioButtons.at(4)).toHaveLength(1)
+      expect(radioButtons.at(5)).toHaveLength(1)
+      expect(optionLabels.at(4).text()).toEqual('Yes')
+      expect(optionLabels.at(5).text()).toEqual('No')
+    })
+
+    test('should render a "Create a new list" button', () => {
+      expect(createNewListLink.text()).toEqual('Create a new list')
+    })
+
+    test('should render a "Save" button', () => {
+      expect(saveButton.text()).toEqual('Save')
+    })
+
+    test('should render a "Cancel" link', () => {
+      expect(cancelLink.text()).toEqual('Cancel')
+    })
+  })
+
+  describe('when saving options', () => {
+    const onSubmitSpy = jest.fn()
+    const wrapper = mount(
+      <AddRemoveFromListForm
+        list={listsWithCompany}
+        onSubmitHandler={onSubmitSpy}
+        isLoading={false}
+        createNewListUrl="/create-url"
+        cancelLinkUrl="/cancel-link"
+      />,
+    )
+    test('should fire a onSubmit handler', () => {
+      wrapper.simulate('submit')
+      expect(onSubmitSpy).toBeCalledTimes(1)
+    })
+  })
+})

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,6 +15,8 @@ export { default as ButtonLink } from './button-link/ButtonLink'
 
 // Company lists
 export { default as DeleteCompanyListSection } from './company-lists/DeleteCompanyListSection'
+export { default as CreateListForm } from './company-lists/CreateListForm'
+export { default as AddRemoveFromListForm } from './company-lists/AddRemoveFromListForm'
 
 // Dashboard
 export { default as MyCompaniesTile } from './dashboard/my-companies/MyCompaniesTile'
@@ -40,6 +42,3 @@ export { default as FieldUneditable } from './forms/elements/FieldUneditable'
 
 // Status message
 export { default as StatusMessage } from './status-message/StatusMessage'
-
-// Company lists
-export { default as CreateListForm } from './company-lists/CreateListForm'


### PR DESCRIPTION
## Description
Users need to be able to add and remove a company from any of the lists they have created. When a user has finished choosing the lists to add or remove to, they can click "Save" which will "when in FE" post the request, after post is complete they re-direct back to the original company page. 

If they wish to create a new list they click the "Create new list" link. If they which to cancel they can click the "Cancel" link which sends them back to the original company page.

Trello - https://trello.com/c/ldY9o5Nr/876-add-or-remove-page
Prototype - https://projects.invisionapp.com/share/GETJGZK7TC6#/screens/379848343

Screen shot of design

![Screenshot 2019-09-27 at 12 25 20](https://user-images.githubusercontent.com/10154302/65766108-ec87bd80-e121-11e9-8270-6e393242a768.png)

Note: Design is just missing the cancel link

