### PR TITLE
chore: add new eslint rules for empty lines, indents and EOF line breaks

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,40 +19,86 @@
     "react-hooks"
   ],
   "rules": {
-    "no-underscore-dangle": ["error", {"allow": ["_source"]}],
+    "no-underscore-dangle": [
+      "error",
+      {
+        "allow": [
+          "_source"
+        ]
+      }
+    ],
     "react-hooks/rules-of-hooks": "error",
     "react-hooks/exhaustive-deps": "off",
     "react/prefer-stateless-function": "off",
     "react/no-multi-comp": "off",
     "react/forbid-prop-types": "off",
-    "react/jsx-boolean-value": ["error", "always"],
+    "react/jsx-boolean-value": [
+      "error",
+      "always"
+    ],
     "react/jsx-one-expression-per-line": "off",
-    "react/sort-comp": ["error", { "order": [
-      "lifecycle",
-      "everything-else",
-      "render"
-    ]}],
-    "semi": ["error", "never"],
+    "react/sort-comp": [
+      "error",
+      {
+        "order": [
+          "lifecycle",
+          "everything-else",
+          "render"
+        ]
+      }
+    ],
+    "semi": [
+      "error",
+      "never"
+    ],
     "object-curly-newline": "off",
     "no-else-return": "off",
     "arrow-body-style": "off",
-    "jsx-a11y/label-has-for": [ 2, {
-      "components": [ "Label" ],
-      "required": {
-        "any": [ "nesting", "id" ]
-      },
-      "allowChildren": false
-    }]
+    "jsx-a11y/label-has-for": [
+      2,
+      {
+        "components": [
+          "Label"
+        ],
+        "required": {
+          "any": [
+            "nesting",
+            "id"
+          ]
+        },
+        "allowChildren": false
+      }
+    ],
+    "indent": [
+      "error",
+      2
+    ],
+    "eol-last": "error",
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1
+      }
+    ]
   },
   "overrides": [
     {
-      "files": ["**.stories.{js,jsx}"],
+      "files": [
+        "**.stories.{js,jsx}"
+      ],
       "rules": {
-        "import/no-extraneous-dependencies": ["error", {"devDependencies": true}]
+        "import/no-extraneous-dependencies": [
+          "error",
+          {
+            "devDependencies": true
+          }
+        ]
       }
     },
     {
-      "files": ["**.test.{js,jsx}"],
+      "files": [
+        "**.test.{js,jsx}"
+      ],
       "env": {
         "jest": true,
         "browser": true

--- a/src/activity-feed/__tests__/Activity.test.jsx
+++ b/src/activity-feed/__tests__/Activity.test.jsx
@@ -16,7 +16,6 @@ import investmentProjectsFDIFixture from '../__fixtures__/investment_projects/pr
 import investmentProjectsNonFDIFixture from '../__fixtures__/investment_projects/project_added_non_fdi'
 import orderAddedFixture from '../__fixtures__/omis/order_added'
 
-
 // Lock the date so moment's relative date doesn't break our deterministic tests.
 MockDate.set(1559750582706)
 

--- a/src/activity-feed/__tests__/ActivityFeed.test.jsx
+++ b/src/activity-feed/__tests__/ActivityFeed.test.jsx
@@ -8,12 +8,10 @@ import Checkbox from '@govuk-react/checkbox'
 import ActivityFeed from '../ActivityFeed'
 import interactionActivityFixture from '../__fixtures__/interactions/interaction'
 
-
 const generateActivities = total => Array.from({ length: total }, () => ({
   ...interactionActivityFixture,
   id: uniqueId(),
 }))
-
 
 describe('ActivityFeed', () => {
   describe('when the feed is empty', () => {
@@ -36,7 +34,6 @@ describe('ActivityFeed', () => {
       expect(tree).toMatchSnapshot()
     })
   })
-
 
   describe('when there are more activities to load', () => {
     test('should render with "Load more" link', () => {

--- a/src/activity-feed/cards/HmrcExporter.jsx
+++ b/src/activity-feed/cards/HmrcExporter.jsx
@@ -43,7 +43,6 @@ export default class HmrcExporter extends React.PureComponent {
       }
     })
 
-
     return (
       <Card>
         <CardHeader>

--- a/src/collection-list/items/ItemMetaWrapper.jsx
+++ b/src/collection-list/items/ItemMetaWrapper.jsx
@@ -2,7 +2,6 @@ import styled from 'styled-components'
 import PropTypes from 'prop-types'
 import { FONT_SIZE, MEDIA_QUERIES, SPACING } from '@govuk-react/constants'
 
-
 const ItemMetaWrapper = styled('div')`
 font-size: ${FONT_SIZE.SIZE_16};
 line-height: ${FONT_SIZE.SIZE_27};

--- a/src/dashboard/my-companies/useMyCompaniesContext.jsx
+++ b/src/dashboard/my-companies/useMyCompaniesContext.jsx
@@ -24,23 +24,23 @@ export const filterCompanyName = (companies, filterText) => (filterText.length
 
 export function reducer(state, action) {
   switch (action.type) {
-    case ACTIONS.SORT_BY:
-      return {
-        ...state,
-        companies: getSortedCompanies(state.companies, action.sortType),
-        sortType: action.sortType,
-      }
-    case ACTIONS.FILTER_BY:
-      return {
-        ...state,
-        filterText: action.filterText,
-        companies: getSortedCompanies(
-          filterCompanyName(state.companiesInitial, action.filterText),
-          state.sortType,
-        ),
-      }
-    default:
-      return state
+  case ACTIONS.SORT_BY:
+    return {
+      ...state,
+      companies: getSortedCompanies(state.companies, action.sortType),
+      sortType: action.sortType,
+    }
+  case ACTIONS.FILTER_BY:
+    return {
+      ...state,
+      filterText: action.filterText,
+      companies: getSortedCompanies(
+        filterCompanyName(state.companiesInitial, action.filterText),
+        state.sortType,
+      ),
+    }
+  default:
+    return state
   }
 }
 

--- a/src/forms/elements/__tests__/FieldWrapper.test.jsx
+++ b/src/forms/elements/__tests__/FieldWrapper.test.jsx
@@ -19,7 +19,6 @@ describe('FieldWrapper', () => {
       expect(wrapper.text()).toContain('Test default')
     })
 
-
     test('should not add a label', () => {
       expect(wrapper.find(Label).exists()).toBeFalsy()
     })

--- a/src/forms/hooks/useForm.js
+++ b/src/forms/hooks/useForm.js
@@ -32,7 +32,6 @@ function useForm({
     'Changes that you made will not be saved.',
   )
 
-
   // Using JSON.stringify() to avoid extra calls as {} !== {}
   useEffect(() => {
     window.scrollTo(0, 0)


### PR DESCRIPTION
**To go in ahead of #189**

To avoid having to check for these formatting issues in the PR stage I've added new eslint rules to restrict empty line to a max of 1, indents to 2 characters and to force a line break at the end of files. 

I've also run `--fix` to remove the errors currently in the codebase. 

This might not all be desirable so is totally open to suggestions. 