### PR TITLE
feat: Add CollectionDownload component

### DIFF
--- a/src/collection-list/CollectionDownload.jsx
+++ b/src/collection-list/CollectionDownload.jsx
@@ -1,0 +1,94 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import pluralise from 'pluralise'
+import {
+  SPACING,
+  MEDIA_QUERIES,
+  BORDER_WIDTH_FORM_ELEMENT,
+} from '@govuk-react/constants'
+import Button from '@govuk-react/button'
+import Paragraph from '@govuk-react/paragraph'
+import { BLACK } from 'govuk-colours'
+
+const StyledWrapper = styled('div')`
+  display: flex;
+  flex-flow: row wrap;
+  border-bottom: ${BORDER_WIDTH_FORM_ELEMENT} solid ${BLACK};
+  margin-bottom: ${SPACING.SCALE_2};
+  padding-bottom: ${SPACING.SCALE_1};
+  align-items: center;
+`
+
+const StyledParagraph = styled(Paragraph)`
+  width: 100%;
+  margin-bottom: ${SPACING.SCALE_1};
+
+  ${MEDIA_QUERIES.TABLET} {
+    width: 0;
+    flex-grow: 1;
+  }
+`
+
+const StyledActions = styled('div')`
+  text-align: right;
+  width: 100%;
+  margin-bottom: ${SPACING.SCALE_1};
+
+  ${MEDIA_QUERIES.TABLET} {
+    width: 0;
+    flex-grow: 1;
+  }
+`
+
+const StyledButton = styled(Button)`
+  margin-bottom: 0;
+`
+
+function CollectionDownload({ totalItems, itemName, downloadUrl }) {
+  const itemPlural = pluralise(2, `${itemName}`)
+  const itemPluralWithCount = pluralise.withCount(totalItems, `% ${itemName}`)
+
+  const SingularText = `You can download this ${itemName}`
+  const PluralText = `You can download these ${itemPluralWithCount}`
+
+  const NoItemsText = `There are no ${itemPlural} to download`
+  const DownloadText = totalItems > 1 ? PluralText : SingularText
+  const NeedToFilterText = `Filter to fewer than 5000 ${itemPlural} to download`
+
+  if (totalItems === 0) {
+    return (
+      <StyledWrapper>
+        <StyledParagraph>{NoItemsText}</StyledParagraph>
+        <StyledActions />
+      </StyledWrapper>
+    )
+  } else if (totalItems <= 5000) {
+    return (
+      <StyledWrapper>
+        <StyledParagraph>{DownloadText}</StyledParagraph>
+        <StyledActions>
+          <StyledButton href={downloadUrl}>Download</StyledButton>
+        </StyledActions>
+      </StyledWrapper>
+    )
+  } else {
+    return (
+      <StyledWrapper>
+        <StyledParagraph>{NeedToFilterText}</StyledParagraph>
+      </StyledWrapper>
+    )
+  }
+}
+
+CollectionDownload.propTypes = {
+  totalItems: PropTypes.number.isRequired,
+  itemName: PropTypes.string.isRequired,
+  downloadUrl: PropTypes.string,
+}
+
+CollectionDownload.defaultProps = {
+  downloadUrl: null,
+}
+
+export default CollectionDownload

--- a/src/collection-list/__fixtures__/capitalProfileHeading.json
+++ b/src/collection-list/__fixtures__/capitalProfileHeading.json
@@ -1,5 +1,6 @@
 {
   "totalItems": 1,
   "itemName": "profile",
-  "addItemUrl": "#"
+  "addItemUrl": "#",
+  "downloadUrl": "#"
 }

--- a/src/collection-list/__stories__/CollectionList.stories.jsx
+++ b/src/collection-list/__stories__/CollectionList.stories.jsx
@@ -8,6 +8,7 @@ import {
 } from '../__fixtures__'
 import CollectionItem from '../CollectionItem'
 import CollectionHeader from '../CollectionHeader'
+import CollectionDownload from '../CollectionDownload'
 
 storiesOf('Collection', module).add('Collection', () => (
   <>
@@ -17,14 +18,73 @@ storiesOf('Collection', module).add('Collection', () => (
       addItemText={capitalProfileHeading.addItemText}
       addItemUrl={capitalProfileHeading.addItemUrl}
     />
+    <CollectionDownload
+      totalItems={capitalProfileHeading.totalItems}
+      itemName={capitalProfileHeading.itemName}
+      downloadUrl={capitalProfileHeading.downloadUrl}
+    />
     <CollectionItem
       id={capitalProfileItem.id}
-      headingUrl={capitalProfileItem.headerUrl}
+      headingUrl={capitalProfileItem.headerLink}
       headingText={capitalProfileItem.headerText}
       badges={capitalProfileItem.badges}
       metadata={capitalProfileItem.metadata}
     />
   </>
+))
+
+storiesOf('Collection', module).add('Collection Header', () => (
+  <CollectionHeader
+    totalItems={capitalProfileHeading.totalItems}
+    itemName={capitalProfileHeading.itemName}
+    addItemText={capitalProfileHeading.addItemText}
+    addItemUrl={capitalProfileHeading.addItemUrl}
+  />
+))
+
+storiesOf('Collection', module).add('Collection Download - no items', () => (
+  <CollectionDownload
+    totalItems={0}
+    itemName={capitalProfileHeading.itemName}
+    downloadUrl={null}
+  />
+))
+
+storiesOf('Collection', module).add('Collection Download - 1 item', () => (
+  <CollectionDownload
+    totalItems={1}
+    itemName={capitalProfileHeading.itemName}
+    downloadUrl={null}
+  />
+))
+
+storiesOf('Collection', module).add('Collection Download - 101 items', () => (
+  <CollectionDownload
+    totalItems={101}
+    itemName={capitalProfileHeading.itemName}
+    downloadUrl={null}
+  />
+))
+
+storiesOf('Collection', module).add(
+  'Collection Download - need to filter',
+  () => (
+    <CollectionDownload
+      totalItems={5001}
+      itemName={capitalProfileHeading.itemName}
+      downloadUrl={capitalProfileHeading.downloadUrl}
+    />
+  )
+)
+
+storiesOf('Collection', module).add('Capital Profile item', () => (
+  <CollectionItem
+    id={capitalProfileItem.id}
+    headingUrl={capitalProfileItem.headerUrl}
+    headingText={capitalProfileItem.headerText}
+    badges={capitalProfileItem.badges}
+    metadata={capitalProfileItem.metadata}
+  />
 ))
 
 storiesOf('Collection', module).add('Collection Header', () => (

--- a/src/collection-list/__tests__/CollectionDownload.test.jsx
+++ b/src/collection-list/__tests__/CollectionDownload.test.jsx
@@ -1,0 +1,80 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import CollectionDownload from '../CollectionDownload'
+import capitalProfileHeading from '../__fixtures__/capitalProfileHeading'
+
+describe('CollectionDownload', () => {
+  let wrapper
+
+  describe('when no items are passed', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionDownload
+          totalItems={0}
+          itemName={capitalProfileHeading.itemName}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionDownload).exists()).toBe(true)
+    })
+
+    test('should render the NoItemsText', () => {
+      expect(wrapper.find('p').text()).toBe('There are no profiles to download')
+    })
+
+    test('should not render the download button', () => {
+      expect(wrapper.find('button').exists()).toBe(false)
+    })
+  })
+
+  describe('when 1 item is passed', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionDownload
+          totalItems={1}
+          itemName={capitalProfileHeading.itemName}
+          downloadUrl={capitalProfileHeading.downloadUrl}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionDownload).exists()).toBe(true)
+    })
+
+    test('should render the DownloadText', () => {
+      expect(wrapper.find('p').text()).toBe('You can download this profile')
+    })
+
+    test('should render the download button', () => {
+      expect(wrapper.find('button').exists()).toBe(true)
+    })
+  })
+
+  describe('when more than 5000 items are passed', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionDownload
+          totalItems={5001}
+          itemName={capitalProfileHeading.itemName}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionDownload).exists()).toBe(true)
+    })
+
+    test('should render the NeedToFilterText', () => {
+      expect(wrapper.find('p').text()).toBe(
+        'Filter to fewer than 5000 profiles to download'
+      )
+    })
+
+    test('should not render the download button', () => {
+      expect(wrapper.find('button').exists()).toBe(false)
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Add `CollectionDownload` component.

The component displays four different things, depending on the number of items passed to it. 

This is the third part of a large piece of work to build out the CollectionList template in React in order to show a list of Large Capital Profiles (and possibly in the future to replace the CollectionList nunjucks macro in the frontend).

## Screenshot


With no items:
![no items](https://user-images.githubusercontent.com/42253716/66058310-0f570f00-e532-11e9-8978-c6ba6f002c69.png)

With 1 item:
![1 item](https://user-images.githubusercontent.com/42253716/66058353-2695fc80-e532-11e9-908b-cae56c7d4b66.png)

With 2 - 5000 items:
![101 items](https://user-images.githubusercontent.com/42253716/66058402-3dd4ea00-e532-11e9-9f81-7c15aa2680e0.png)

With 5001+ items:
![5001 items](https://user-images.githubusercontent.com/42253716/66058453-51805080-e532-11e9-801a-d2313df2646c.png)


The aim is to get to something resembling the below screenshot:

![0001](https://user-images.githubusercontent.com/42253716/65255451-d2ccf180-daf5-11e9-9417-b3e40e90556f.jpg)