### PR TITLE
refactor: replace SASS syntax with explicit styled component in CollectionHeader

### DIFF
--- a/src/collection-list/CollectionHeader.jsx
+++ b/src/collection-list/CollectionHeader.jsx
@@ -17,12 +17,12 @@ const StyledSummary = styled('div')`
 
 const StyledCount = styled('div')`
   margin-top: ${SPACING.SCALE_1};
+`
 
-  & > H2 {
-    font-weight: normal;
-    font-size: ${FONT_SIZE.SIZE_27};
-    margin-bottom: 0;
-  }
+const StyledH2 = styled(H2)`
+  font-weight: normal;
+  font-size: ${FONT_SIZE.SIZE_27};
+  margin-bottom: 0;
 `
 
 const StyledActions = styled('div')`
@@ -49,7 +49,7 @@ function CollectionHeader({
   return (
     <StyledSummary>
       <StyledCount>
-        <H2>{headerText}</H2>
+        <StyledH2>{headerText}</StyledH2>
       </StyledCount>
       <StyledActions>
         {addItemUrl && (


### PR DESCRIPTION
This is a small refactor to remove the use of SASS syntax in the `CollectionHeader` component in favour of an explicit styled component. There is no visual change. 

This should make the CSS easier to read and understand. 

For consistency, it might be a good idea to refactor the SASS syntax across all components, but this will have to be with the approval of Product & Delivery. 