### PR TITLE
feat: add CollectionPagination component

### DIFF
--- a/src/collection-list/CollectionPagination.jsx
+++ b/src/collection-list/CollectionPagination.jsx
@@ -80,7 +80,7 @@ function CollectionPagination({
   next,
   pages,
 }) {
-  function getPages(page, current) {
+  function getPage(page, current) {
     if (!page.url) {
       return <StyledSpan>{page.label}</StyledSpan>
     }
@@ -95,7 +95,7 @@ function CollectionPagination({
       {previous && <StyledPrevious href={previous}>Previous</StyledPrevious>}
       <StyledList>
         {pages.map((page) => (
-          <StyledListItem>{getPages(page, currentPage)}</StyledListItem>
+          <StyledListItem>{getPage(page, currentPage)}</StyledListItem>
         ))}
       </StyledList>
       {next && <StyledNext href={next}>Next</StyledNext>}

--- a/src/collection-list/CollectionPagination.jsx
+++ b/src/collection-list/CollectionPagination.jsx
@@ -84,7 +84,7 @@ function CollectionPagination({
     if (!page.url) {
       return <StyledSpan>{page.label}</StyledSpan>
     }
-    if (page.label === JSON.stringify(current)) {
+    if (page.label === String(current)) {
       return <StyledCurrentAnchor>{page.label}</StyledCurrentAnchor>
     }
     return <StyledAnchor href={page.url}>{page.label}</StyledAnchor>

--- a/src/collection-list/CollectionPagination.jsx
+++ b/src/collection-list/CollectionPagination.jsx
@@ -1,0 +1,127 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import { SPACING, MEDIA_QUERIES, FONT_SIZE } from '@govuk-react/constants'
+import { GREY_4, LINK_COLOUR, GREY_3, TEXT_COLOUR, GREY_1 } from 'govuk-colours'
+
+const StyledNav = styled('nav')`
+  text-align: center;
+  line-height: 1;
+  display: flex;
+  justify-content: space-around;
+  padding: ${SPACING.SCALE_3};
+
+  ${MEDIA_QUERIES.TABLET} {
+    display: block;
+  }
+`
+
+const StyledAnchor = styled('a')`
+  font-weight: bold;
+  font-size: ${FONT_SIZE.SIZE_16};
+  display: inline-block;
+  padding: ${SPACING.SCALE_2} ${SPACING.SCALE_3};
+  background-color: ${GREY_4};
+  line-height: ${FONT_SIZE.SIZE_24};
+  color: ${LINK_COLOUR};
+  text-decoration: none;
+
+    :hover {
+      background-color: ${GREY_3};
+    }
+  }
+`
+
+const StyledCurrentAnchor = styled(StyledAnchor)`
+  background-color: transparent;
+  color: ${TEXT_COLOUR};
+  text-decoration: none;
+`
+
+const StyledPrevious = styled(StyledAnchor)`
+  margin-right: ${SPACING.SCALE_1};
+`
+
+const StyledNext = styled(StyledAnchor)`
+  margin-left: ${SPACING.SCALE_1};
+`
+
+const StyledList = styled('ul')`
+  display: none;
+
+  ${MEDIA_QUERIES.TABLET} {
+    display: inline-block;
+    padding: 0;
+  }
+`
+
+const StyledListItem = styled('li')`
+  display: inline-block;
+
+  & + & {
+    margin-left: ${SPACING.SCALE_1};
+  }
+`
+
+const StyledSpan = styled('span')`
+  font-weight: bold;
+  font-size: ${FONT_SIZE.SIZE_16};
+  display: inline-block;
+  padding: ${SPACING.SCALE_2};
+  background-color: transparent;
+  line-height: ${FONT_SIZE.SIZE_24};
+  color: ${GREY_1};
+`
+function CollectionPagination({
+  totalPages,
+  currentPage,
+  previous,
+  next,
+  pages,
+}) {
+  return totalPages === 1 ? null : (
+    <StyledNav aria-label={`pagination: total ${totalPages} pages`}>
+      {previous && <StyledPrevious href={previous}>Previous</StyledPrevious>}
+      <StyledList>
+        {pages.map((page) => {
+          if (page.url && page.label === JSON.stringify(currentPage)) {
+            return (
+              <StyledListItem>
+                <StyledCurrentAnchor>{page.label}</StyledCurrentAnchor>
+              </StyledListItem>
+            )
+          } else if (page.url) {
+            return (
+              <StyledListItem>
+                <StyledAnchor href={page.url}>{page.label}</StyledAnchor>
+              </StyledListItem>
+            )
+          } else {
+            return (
+              <StyledListItem>
+                <StyledSpan>{page.label}</StyledSpan>
+              </StyledListItem>
+            )
+          }
+        })}
+      </StyledList>
+      {next && <StyledNext href={next}>Next</StyledNext>}
+    </StyledNav>
+  )
+}
+
+CollectionPagination.propTypes = {
+  totalPages: PropTypes.number.isRequired,
+  currentPage: PropTypes.number.isRequired,
+  previous: PropTypes.string,
+  next: PropTypes.string,
+  pages: PropTypes.array,
+}
+
+CollectionPagination.defaultProps = {
+  previous: null,
+  next: null,
+  pages: null,
+}
+
+export default CollectionPagination

--- a/src/collection-list/CollectionPagination.jsx
+++ b/src/collection-list/CollectionPagination.jsx
@@ -72,6 +72,7 @@ const StyledSpan = styled('span')`
   line-height: ${FONT_SIZE.SIZE_24};
   color: ${GREY_1};
 `
+
 function CollectionPagination({
   totalPages,
   currentPage,
@@ -79,31 +80,23 @@ function CollectionPagination({
   next,
   pages,
 }) {
+  function getPages(page, current) {
+    if (!page.url) {
+      return <StyledSpan>{page.label}</StyledSpan>
+    }
+    if (page.label === JSON.stringify(current)) {
+      return <StyledCurrentAnchor>{page.label}</StyledCurrentAnchor>
+    }
+    return <StyledAnchor href={page.url}>{page.label}</StyledAnchor>
+  }
+
   return totalPages === 1 ? null : (
     <StyledNav aria-label={`pagination: total ${totalPages} pages`}>
       {previous && <StyledPrevious href={previous}>Previous</StyledPrevious>}
       <StyledList>
-        {pages.map((page) => {
-          if (page.url && page.label === JSON.stringify(currentPage)) {
-            return (
-              <StyledListItem>
-                <StyledCurrentAnchor>{page.label}</StyledCurrentAnchor>
-              </StyledListItem>
-            )
-          } else if (page.url) {
-            return (
-              <StyledListItem>
-                <StyledAnchor href={page.url}>{page.label}</StyledAnchor>
-              </StyledListItem>
-            )
-          } else {
-            return (
-              <StyledListItem>
-                <StyledSpan>{page.label}</StyledSpan>
-              </StyledListItem>
-            )
-          }
-        })}
+        {pages.map((page) => (
+          <StyledListItem>{getPages(page, currentPage)}</StyledListItem>
+        ))}
       </StyledList>
       {next && <StyledNext href={next}>Next</StyledNext>}
     </StyledNav>

--- a/src/collection-list/__fixtures__/index.js
+++ b/src/collection-list/__fixtures__/index.js
@@ -1,3 +1,4 @@
 export { default as capitalProfileItem } from './capitalProfileItem'
 export { default as interactionItem } from './interactionItem'
 export { default as capitalProfileHeading } from './capitalProfileHeading'
+export { default as paginationProps } from './paginationProps'

--- a/src/collection-list/__fixtures__/paginationProps.json
+++ b/src/collection-list/__fixtures__/paginationProps.json
@@ -1,0 +1,31 @@
+{
+    "totalPages": 7,
+    "currentPage": 2,
+    "previous": "#",
+    "next": "#",
+    "pages": [
+        {
+            "label": "1",
+            "url": "#"
+        },
+        {
+            "label": "2",
+            "url": "#"
+        },
+        {
+            "label": "3",
+            "url": "#"
+        },
+        {
+            "label": "4",
+            "url": "#"
+        },
+        {
+            "label": "..."
+        },
+        {
+            "label": "7",
+            "url": "#"
+        }
+    ]
+}

--- a/src/collection-list/__stories__/CollectionList.stories.jsx
+++ b/src/collection-list/__stories__/CollectionList.stories.jsx
@@ -5,10 +5,12 @@ import {
   capitalProfileItem,
   interactionItem,
   capitalProfileHeading,
+  paginationProps,
 } from '../__fixtures__'
 import CollectionItem from '../CollectionItem'
 import CollectionHeader from '../CollectionHeader'
 import CollectionDownload from '../CollectionDownload'
+import CollectionPagination from '../CollectionPagination'
 
 storiesOf('Collection', module).add('Collection', () => (
   <>
@@ -29,6 +31,13 @@ storiesOf('Collection', module).add('Collection', () => (
       headingText={capitalProfileItem.headerText}
       badges={capitalProfileItem.badges}
       metadata={capitalProfileItem.metadata}
+    />
+    <CollectionPagination
+      totalPages={paginationProps.totalPages}
+      currentPage={paginationProps.currentPage}
+      previous={paginationProps.previous}
+      next={paginationProps.next}
+      pages={paginationProps.pages}
     />
   </>
 ))
@@ -113,5 +122,15 @@ storiesOf('Collection', module).add('Interaction item', () => (
     headingText={interactionItem.headerText}
     badges={interactionItem.badges}
     metadata={interactionItem.metadata}
+  />
+))
+
+storiesOf('Collection', module).add('Collection pagination', () => (
+  <CollectionPagination
+    totalPages={paginationProps.totalPages}
+    currentPage={paginationProps.currentPage}
+    previous={paginationProps.previous}
+    next={paginationProps.next}
+    pages={paginationProps.pages}
   />
 ))

--- a/src/collection-list/__tests__/CollectionPagination.test.jsx
+++ b/src/collection-list/__tests__/CollectionPagination.test.jsx
@@ -1,0 +1,212 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import CollectionPagination from '../CollectionPagination'
+import paginationProps from '../__fixtures__/paginationProps'
+
+describe('CollectionPagination', () => {
+  let wrapper
+
+  describe('when 7 pages are passed', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionPagination
+          totalPages={paginationProps.totalPages}
+          currentPage={paginationProps.currentPage}
+          previous={paginationProps.previous}
+          next={paginationProps.next}
+          pages={paginationProps.pages}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionPagination).exists()).toBe(true)
+    })
+
+    test('should render the previous button', () => {
+      expect(
+        wrapper
+          .find('a')
+          .first()
+          .text()
+      ).toBe('Previous')
+    })
+
+    test('should render the next button', () => {
+      expect(
+        wrapper
+          .find('a')
+          .last()
+          .text()
+      ).toBe('Next')
+    })
+
+    test('should render all the page links', () => {
+      expect(wrapper.find('li')).toHaveLength(6)
+    })
+
+    test('should render the current page link without href', () => {
+      expect(wrapper.find("a[href='#']")).toHaveLength(6)
+    })
+  })
+
+  describe('when 3 pages are passed', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionPagination
+          totalPages={3}
+          currentPage={2}
+          previous="#"
+          next="#"
+          pages={[
+            {
+              label: '1',
+              url: '#',
+            },
+            {
+              label: '2',
+              url: '#',
+            },
+            {
+              label: '3',
+              url: '#',
+            },
+          ]}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionPagination).exists()).toBe(true)
+    })
+
+    test('should render the previous button', () => {
+      expect(
+        wrapper
+          .find('a')
+          .first()
+          .text()
+      ).toBe('Previous')
+    })
+
+    test('should render the next button', () => {
+      expect(
+        wrapper
+          .find('a')
+          .last()
+          .text()
+      ).toBe('Next')
+    })
+
+    test('should render all the page links', () => {
+      expect(wrapper.find('li')).toHaveLength(3)
+    })
+
+    test('should render the current page link without href', () => {
+      expect(wrapper.find("a[href='#']")).toHaveLength(4)
+    })
+  })
+
+  describe('when just 1 page is passed', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionPagination
+          totalPages={1}
+          currentPage={1}
+          previous={null}
+          next={null}
+          pages={[
+            {
+              label: '1',
+              url: '#',
+            },
+          ]}
+        />
+      )
+    })
+
+    test('should not render the component', () => {
+      expect(wrapper.find('nav').exists()).toBe(false)
+    })
+  })
+
+  describe('when 2 pages are passed and the current page is page 1', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionPagination
+          totalPages={2}
+          currentPage={1}
+          previous={null}
+          next="#"
+          pages={[
+            {
+              label: '1',
+              url: '#',
+            },
+            {
+              label: '2',
+              url: '#',
+            },
+          ]}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionPagination).exists()).toBe(true)
+    })
+
+    test('should not render the previous button', () => {
+      expect(wrapper.findWhere((a) => a.text() === 'Previous')).toHaveLength(0)
+    })
+
+    test('should render the next button', () => {
+      expect(
+        wrapper
+          .find('a')
+          .last()
+          .text()
+      ).toBe('Next')
+    })
+  })
+
+  describe('when 2 pages are passed and the current page is page 2', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionPagination
+          totalPages={2}
+          currentPage={2}
+          previous="#"
+          next={null}
+          pages={[
+            {
+              label: '1',
+              url: '#',
+            },
+            {
+              label: '2',
+              url: '#',
+            },
+          ]}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionPagination).exists()).toBe(true)
+    })
+
+    test('should not render the next button', () => {
+      expect(wrapper.findWhere((a) => a.text() === 'Next')).toHaveLength(0)
+    })
+
+    test('should render the previous button', () => {
+      expect(
+        wrapper
+          .find('a')
+          .first()
+          .text()
+      ).toBe('Previous')
+    })
+  })
+})


### PR DESCRIPTION
## Description of change

Add `CollectionPagination` component.

The component displays only the previous and next button on mobile view (if passed) and does not render at all if there is only 1 page. (the below screenshot is an exception as I've passed 7 pages to the component in storybook - despite it saying 1 profile).

This is the fourth part of a large piece of work to build out the CollectionList template in React in order to show a list of Large Capital Profiles (and possibly in the future to replace the CollectionList nunjucks macro in the frontend).

## Screenshot

Desktop view:
![Screenshot 2019-10-08 at 13 51 05](https://user-images.githubusercontent.com/42253716/66396935-b294a200-e9d2-11e9-93a7-9949e34ea086.png)

Mobile view:
![Screenshot 2019-10-08 at 13 51 53](https://user-images.githubusercontent.com/42253716/66396985-cdffad00-e9d2-11e9-8d2a-6371483b7785.png)