### PR TITLE
feat: Add ID to FieldWrapper

### DIFF
--- a/src/forms/elements/FieldRadios.jsx
+++ b/src/forms/elements/FieldRadios.jsx
@@ -38,6 +38,7 @@ const FieldRadios = ({
                 checked={value === optionValue}
                 onChange={onChange}
                 onBlur={onBlur}
+                name={name}
                 {...optionProps}
               >
                 {optionLabel}

--- a/src/forms/elements/FieldWrapper.jsx
+++ b/src/forms/elements/FieldWrapper.jsx
@@ -88,7 +88,7 @@ const FieldWrapper = ({
   showBorder,
   children,
 }) => (
-  <FormGroup>
+  <FormGroup id={`field-${name}`}>
     <FieldInner legend={legend} error={error} showBorder={showBorder}>
       {label && (
         <StyledLabel error={error} htmlFor={name}>

--- a/src/forms/elements/__tests__/FieldRadios.test.jsx
+++ b/src/forms/elements/__tests__/FieldRadios.test.jsx
@@ -89,13 +89,18 @@ describe('FieldRadios', () => {
     })
 
     test('should render a label for each option', () => {
-      expect(radios.first().text()).toEqual('testOptionLabel1')
+      expect(radios.at(0).text()).toEqual('testOptionLabel1')
       expect(radios.at(1).text()).toEqual('testOptionLabel2')
     })
 
     test('should render a value for each option', () => {
-      expect(radios.first().prop('value')).toEqual('testOptionValue1')
+      expect(radios.at(0).prop('value')).toEqual('testOptionValue1')
       expect(radios.at(1).prop('value')).toEqual('testOptionValue2')
+    })
+
+    test('should render with a name attribute for each option', () => {
+      expect(radios.at(0).prop('name')).toEqual('testField')
+      expect(radios.at(1).prop('name')).toEqual('testField')
     })
   })
 
@@ -140,7 +145,7 @@ describe('FieldRadios', () => {
 
       wrapper
         .find('input')
-        .first()
+        .at(0)
         .simulate('change', {
           target: {
             checked: true,
@@ -157,7 +162,7 @@ describe('FieldRadios', () => {
       expect(
         wrapper
           .find('input')
-          .first()
+          .at(0)
           .prop('checked')
       ).toBeTruthy()
     })

--- a/src/forms/elements/__tests__/FieldWrapper.test.jsx
+++ b/src/forms/elements/__tests__/FieldWrapper.test.jsx
@@ -23,6 +23,10 @@ describe('FieldWrapper', () => {
       expect(wrapper.text()).toContain('Test default')
     })
 
+    test('should set the ID', () => {
+      expect(wrapper.children().prop('id')).toEqual('field-testName')
+    })
+
     test('should not add a label', () => {
       expect(wrapper.find(Label).exists()).toBeFalsy()
     })


### PR DESCRIPTION
Add ID to the `FieldWrapper` component to make form testing easier, no visual changes.