### PR TITLE
Style to be more inline with the data hub updates section

### DIFF
--- a/src/dashboard/my-companies/ListSelector.jsx
+++ b/src/dashboard/my-companies/ListSelector.jsx
@@ -3,7 +3,7 @@ import styled from 'styled-components'
 import { H2, H3 } from '@govuk-react/heading'
 import Link from '@govuk-react/link'
 import Select from '@govuk-react/select'
-import { SPACING } from '@govuk-react/constants'
+import { SPACING, LEVEL_SIZE } from '@govuk-react/constants'
 import useMyCompaniesContext from './useMyCompaniesContext'
 import { LIST_CHANGE } from './constants'
 
@@ -12,7 +12,7 @@ const StyledRoot = styled.div({
   alignItems: 'baseline',
 })
 
-const StyledHedline = styled(H2)({
+const StyledHeadline = styled(H2)({
   flexGrow: 1,
 })
 
@@ -43,7 +43,7 @@ export default () => {
   } = useMyCompaniesContext()
   return (
     <StyledRoot>
-      <StyledHedline>My companies list</StyledHedline>
+      <StyledHeadline size={LEVEL_SIZE[3]}>My Companies Lists</StyledHeadline>
       {lists.length ? (
         <>
           {lists.length === 1 ? (

--- a/src/dashboard/my-companies/MyCompaniesTile.jsx
+++ b/src/dashboard/my-companies/MyCompaniesTile.jsx
@@ -1,9 +1,17 @@
 import React from 'react'
 import HintText from '@govuk-react/hint-text'
+import { SPACING } from '@govuk-react/constants'
+import { GREY_2 } from 'govuk-colours'
+import styled from 'styled-components'
 
 import useMyCompaniesContext from './useMyCompaniesContext'
 import MyCompaniesTable from './MyCompaniesTable'
 import ListSelector from './ListSelector'
+
+const StyledDiv = styled.div({
+  borderTop: `4px solid ${GREY_2}`,
+  paddingTop: SPACING.SCALE_3,
+})
 
 const EmptyListMsg = () => (
   <HintText>
@@ -32,7 +40,7 @@ function MyCompaniesTile() {
   const hasCompanies = list && list.companies && list.companies.length
 
   return (
-    <div>
+    <StyledDiv>
       <ListSelector />
       {/* eslint-disable no-nested-ternary */}
       {hasLists ? (
@@ -44,7 +52,7 @@ function MyCompaniesTile() {
       ) : (
         <NoListsMsg />
       )}
-    </div>
+    </StyledDiv>
   )
 }
 

--- a/src/dashboard/my-companies/MyCompaniesTile.jsx
+++ b/src/dashboard/my-companies/MyCompaniesTile.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import HintText from '@govuk-react/hint-text'
-import { SPACING } from '@govuk-react/constants'
+import { SPACING, BORDER_WIDTH_MOBILE } from '@govuk-react/constants'
 import { GREY_2 } from 'govuk-colours'
 import styled from 'styled-components'
 
@@ -9,7 +9,7 @@ import MyCompaniesTable from './MyCompaniesTable'
 import ListSelector from './ListSelector'
 
 const StyledDiv = styled.div({
-  borderTop: `4px solid ${GREY_2}`,
+  borderTop: `${BORDER_WIDTH_MOBILE} solid ${GREY_2}`,
   paddingTop: SPACING.SCALE_3,
 })
 

--- a/src/dashboard/my-companies/__tests__/ListSelector.test.jsx
+++ b/src/dashboard/my-companies/__tests__/ListSelector.test.jsx
@@ -11,7 +11,7 @@ describe('ListSelector', () => {
         <ListSelector />
       </useMyCompaniesContext.Provider>
     )
-    expect(wrapper.text()).toBe('My companies list')
+    expect(wrapper.text()).toBe('My Companies Lists')
   })
 
   test('One list', () => {
@@ -20,7 +20,7 @@ describe('ListSelector', () => {
         <ListSelector />
       </useMyCompaniesContext.Provider>
     )
-    expect(wrapper.text()).toBe('My companies listFooEdit lists')
+    expect(wrapper.text()).toBe('My Companies ListsFooEdit lists')
   })
 
   describe('Three lists', () => {
@@ -33,7 +33,7 @@ describe('ListSelector', () => {
         </useMyCompaniesContext.Provider>
       )
       expect(wrapper.text()).toBe(
-        'My companies listView listBarBazFooEdit lists'
+        'My Companies ListsView listBarBazFooEdit lists'
       )
       expect(
         wrapper.containsAllMatchingElements([

--- a/src/dashboard/my-companies/__tests__/MyCompaniesTile.test.jsx
+++ b/src/dashboard/my-companies/__tests__/MyCompaniesTile.test.jsx
@@ -17,7 +17,7 @@ describe('My companies dashboard', () => {
     const wrapper = fixture([])
     expect(wrapper.find(MyCompaniesTable)).toHaveLength(0)
     expect(wrapper.text()).toBe(
-      'My companies list' +
+      'My Companies Lists' +
         'You have not yet created any lists with companies.' +
         'You can add companies to lists from a company page, ' +
         'and only you can see these lists.'
@@ -28,7 +28,7 @@ describe('My companies dashboard', () => {
     const wrapper = fixture([{ name: 'Foo', companies: [] }])
     expect(wrapper.find(MyCompaniesTable)).toHaveLength(0)
     expect(wrapper.text()).toBe(
-      'My companies list' +
+      'My Companies Lists' +
         'Foo' +
         'Edit lists' +
         'You have not added any companies to your list.' +
@@ -46,7 +46,7 @@ describe('My companies dashboard', () => {
       ])
       expect(wrapper.find(MyCompaniesTable)).toHaveLength(0)
       expect(wrapper.text()).toBe(
-        'My companies list' +
+        'My Companies Lists' +
           'View list' +
           'Bar' +
           'Baz' +


### PR DESCRIPTION
Small style additions to make this more consistent with the section above "Data Hub Updates" section. Header was too large and we were missing the border at the top of the section.