### PR TITLE
Feature/delete list link

### DIFF
--- a/src/dashboard/__stories__/DashboardSection.stories.jsx
+++ b/src/dashboard/__stories__/DashboardSection.stories.jsx
@@ -13,38 +13,48 @@ const WithData = (props) => (
 storiesOf('Dashboard')
   .add('No lists', () => <WithData />)
   .add('One empty list', () => (
-    <WithData lists={[{ name: "I'm empty", companies: [] }]} />
+    <WithData
+      deleteListPropsAccessor={({ id }) => ({ href: id })}
+      lists={[{ id: 'foo', name: "I'm empty", companies: [] }]}
+    />
   ))
   .add('One full list', () => (
-    <WithData lists={[{ name: 'Foo', companies: allCompanies }]} />
+    <WithData
+      deleteListPropsAccessor={({ id }) => ({ href: id })}
+      lists={[{ id: 'foo', name: 'Foo', companies: allCompanies }]}
+    />
   ))
   .add('Three lists, first empty', () => (
     <WithData
+      deleteListPropsAccessor={({ id }) => ({ href: id })}
       lists={[
-        { name: 'Foo', companies: allCompanies },
-        { name: 'Bar', companies: [] },
-        { name: 'Baz', companies: allCompanies.slice(0, -1) },
+        { id: 'foo', name: 'Foo', companies: allCompanies },
+        { id: 'bar', name: 'Bar', companies: [] },
+        { id: 'baz', name: 'Baz', companies: allCompanies.slice(0, -1) },
       ]}
     />
   ))
   .add('Three lists, first with single company', () => (
     <WithData
+      deleteListPropsAccessor={({ id }) => ({ href: id })}
       lists={[
-        { name: 'Foo', companies: allCompanies },
-        { name: 'Bar', companies: allCompanies.slice(1, 2) },
-        { name: 'Baz', companies: allCompanies.slice(0, -1) },
+        { id: 'foo', name: 'Foo', companies: allCompanies },
+        { id: 'bar', name: 'Bar', companies: allCompanies.slice(1, 2) },
+        { id: 'baz', name: 'Baz', companies: allCompanies.slice(0, -1) },
       ]}
     />
   ))
   .add('Three company lists', () => (
     <WithData
+      deleteListPropsAccessor={({ id }) => ({ href: id })}
       lists={[
         {
+          id: 'foo',
           name: 'Very long list name lorem ipsum dolor sit amet',
           companies: allCompanies,
         },
-        { name: 'Bar', companies: allCompanies.slice(1) },
-        { name: 'Baz', companies: allCompanies.slice(0, -1) },
+        { id: 'bar', name: 'Bar', companies: allCompanies.slice(1) },
+        { id: 'baz', name: 'Baz', companies: allCompanies.slice(0, -1) },
       ]}
     />
   ))

--- a/src/dashboard/my-companies/ListSelector.jsx
+++ b/src/dashboard/my-companies/ListSelector.jsx
@@ -37,9 +37,9 @@ const StyledSelect = styled(Select)({
 
 export default () => {
   const {
-    state: { lists },
+    state: { lists, selectedIdx },
     dispatch,
-    editListsLinkProps,
+    deleteListPropsAccessor = () => ({}),
   } = useMyCompaniesContext()
   return (
     <StyledRoot>
@@ -69,7 +69,9 @@ export default () => {
               </StyledSelect>
             </>
           )}
-          <Link {...editListsLinkProps}>Edit lists</Link>
+          <Link {...deleteListPropsAccessor(lists[selectedIdx])}>
+            Delete this list
+          </Link>
         </>
       ) : null}
     </StyledRoot>

--- a/src/dashboard/my-companies/__tests__/ListSelector.test.jsx
+++ b/src/dashboard/my-companies/__tests__/ListSelector.test.jsx
@@ -24,21 +24,25 @@ describe('ListSelector', () => {
   test('One list', () => {
     const wrapper = mount(
       <useMyCompaniesContext.Provider
-        lists={[{ name: 'Foo' }]}
+        lists={[{ id: 'foo', name: 'Foo' }]}
         deleteListPropsAccessor={deleteListPropAccessor}
       >
         <ListSelector />
       </useMyCompaniesContext.Provider>
     )
     expect(wrapper.text()).toBe('My Companies ListsFooDelete this list')
-    assertDeleteListLinkProps(wrapper, { name: 'Foo' })
+    assertDeleteListLinkProps(wrapper, { id: 'foo', name: 'Foo' })
   })
 
   describe('Three lists', () => {
     test('Render', () => {
       const wrapper = mount(
         <useMyCompaniesContext.Provider
-          lists={[{ name: 'Foo' }, { name: 'Bar' }, { name: 'Baz' }]}
+          lists={[
+            { id: 'foo', name: 'Foo' },
+            { id: 'bar', name: 'Bar' },
+            { id: 'bar', name: 'Baz' },
+          ]}
           deleteListPropsAccessor={deleteListPropAccessor}
         >
           <ListSelector />
@@ -54,7 +58,7 @@ describe('ListSelector', () => {
           <option value={2}>Foo</option>,
         ])
       ).toBe(true)
-      assertDeleteListLinkProps(wrapper, { name: 'Bar' })
+      assertDeleteListLinkProps(wrapper, { id: 'bar', name: 'Bar' })
     })
 
     test('Interaction to state', () => {
@@ -67,7 +71,11 @@ describe('ListSelector', () => {
 
       const wrapper = mount(
         <useMyCompaniesContext.Provider
-          lists={[{ name: 'Foo' }, { name: 'Bar' }, { name: 'Baz' }]}
+          lists={[
+            { id: 'foo', name: 'Foo' },
+            { id: 'bar', name: 'Bar' },
+            { id: 'baz', name: 'Baz' },
+          ]}
           deleteListPropsAccessor={deleteListPropAccessor}
         >
           <ListSelector />
@@ -75,24 +83,24 @@ describe('ListSelector', () => {
         </useMyCompaniesContext.Provider>
       )
 
-      assertDeleteListLinkProps(wrapper, { name: 'Bar' })
+      assertDeleteListLinkProps(wrapper, { id: 'bar', name: 'Bar' })
 
       const select = wrapper.find('select')
 
       select.simulate('change', withTargetValue(2))
-      assertDeleteListLinkProps(wrapper, { name: 'Foo' })
+      assertDeleteListLinkProps(wrapper, { id: 'foo', name: 'Foo' })
 
       select.simulate('change', withTargetValue(1))
-      assertDeleteListLinkProps(wrapper, { name: 'Baz' })
+      assertDeleteListLinkProps(wrapper, { id: 'baz', name: 'Baz' })
 
       select.simulate('change', withTargetValue(0))
-      assertDeleteListLinkProps(wrapper, { name: 'Bar' })
+      assertDeleteListLinkProps(wrapper, { id: 'bar', name: 'Bar' })
 
       select.simulate('change', withTargetValue(1))
-      assertDeleteListLinkProps(wrapper, { name: 'Baz' })
+      assertDeleteListLinkProps(wrapper, { id: 'baz', name: 'Baz' })
 
       select.simulate('change', withTargetValue(2))
-      assertDeleteListLinkProps(wrapper, { name: 'Foo' })
+      assertDeleteListLinkProps(wrapper, { id: 'foo', name: 'Foo' })
 
       expect(stateHistory).toEqual([0, 2, 1, 0, 1, 2])
     })

--- a/src/dashboard/my-companies/__tests__/ListSelector.test.jsx
+++ b/src/dashboard/my-companies/__tests__/ListSelector.test.jsx
@@ -4,6 +4,13 @@ import useMyCompaniesContext from '../useMyCompaniesContext'
 import ListSelector from '../ListSelector'
 import { withTargetValue } from '../../../utils/enzyme'
 
+const deleteListPropAccessor = (list) => ({
+  'data-test': list,
+})
+
+const assertDeleteListLinkProps = (wrapper, props) =>
+  expect(wrapper.find('a').prop('data-test')).toEqual(props)
+
 describe('ListSelector', () => {
   test('No lists', () => {
     const wrapper = mount(
@@ -16,11 +23,15 @@ describe('ListSelector', () => {
 
   test('One list', () => {
     const wrapper = mount(
-      <useMyCompaniesContext.Provider lists={[{ name: 'Foo' }]}>
+      <useMyCompaniesContext.Provider
+        lists={[{ name: 'Foo' }]}
+        deleteListPropsAccessor={deleteListPropAccessor}
+      >
         <ListSelector />
       </useMyCompaniesContext.Provider>
     )
     expect(wrapper.text()).toBe('My Companies ListsFooDelete this list')
+    assertDeleteListLinkProps(wrapper, { name: 'Foo' })
   })
 
   describe('Three lists', () => {
@@ -28,6 +39,7 @@ describe('ListSelector', () => {
       const wrapper = mount(
         <useMyCompaniesContext.Provider
           lists={[{ name: 'Foo' }, { name: 'Bar' }, { name: 'Baz' }]}
+          deleteListPropsAccessor={deleteListPropAccessor}
         >
           <ListSelector />
         </useMyCompaniesContext.Provider>
@@ -42,6 +54,7 @@ describe('ListSelector', () => {
           <option value={2}>Foo</option>,
         ])
       ).toBe(true)
+      assertDeleteListLinkProps(wrapper, { name: 'Bar' })
     })
 
     test('Interaction to state', () => {
@@ -55,19 +68,31 @@ describe('ListSelector', () => {
       const wrapper = mount(
         <useMyCompaniesContext.Provider
           lists={[{ name: 'Foo' }, { name: 'Bar' }, { name: 'Baz' }]}
+          deleteListPropsAccessor={deleteListPropAccessor}
         >
           <ListSelector />
           <Mock />
         </useMyCompaniesContext.Provider>
       )
 
-      wrapper
-        .find('select')
-        .simulate('change', withTargetValue(2))
-        .simulate('change', withTargetValue(1))
-        .simulate('change', withTargetValue(0))
-        .simulate('change', withTargetValue(1))
-        .simulate('change', withTargetValue(2))
+      assertDeleteListLinkProps(wrapper, { name: 'Bar' })
+
+      const select = wrapper.find('select')
+
+      select.simulate('change', withTargetValue(2))
+      assertDeleteListLinkProps(wrapper, { name: 'Foo' })
+
+      select.simulate('change', withTargetValue(1))
+      assertDeleteListLinkProps(wrapper, { name: 'Baz' })
+
+      select.simulate('change', withTargetValue(0))
+      assertDeleteListLinkProps(wrapper, { name: 'Bar' })
+
+      select.simulate('change', withTargetValue(1))
+      assertDeleteListLinkProps(wrapper, { name: 'Baz' })
+
+      select.simulate('change', withTargetValue(2))
+      assertDeleteListLinkProps(wrapper, { name: 'Foo' })
 
       expect(stateHistory).toEqual([0, 2, 1, 0, 1, 2])
     })

--- a/src/dashboard/my-companies/__tests__/ListSelector.test.jsx
+++ b/src/dashboard/my-companies/__tests__/ListSelector.test.jsx
@@ -20,7 +20,7 @@ describe('ListSelector', () => {
         <ListSelector />
       </useMyCompaniesContext.Provider>
     )
-    expect(wrapper.text()).toBe('My Companies ListsFooEdit lists')
+    expect(wrapper.text()).toBe('My Companies ListsFooDelete this list')
   })
 
   describe('Three lists', () => {
@@ -33,7 +33,7 @@ describe('ListSelector', () => {
         </useMyCompaniesContext.Provider>
       )
       expect(wrapper.text()).toBe(
-        'My Companies ListsView listBarBazFooEdit lists'
+        'My Companies ListsView listBarBazFooDelete this list'
       )
       expect(
         wrapper.containsAllMatchingElements([

--- a/src/dashboard/my-companies/__tests__/MyCompaniesTable.test.jsx
+++ b/src/dashboard/my-companies/__tests__/MyCompaniesTable.test.jsx
@@ -11,7 +11,7 @@ const getTableRowTexts = (wrapper) =>
 const fixture = (companies) =>
   mount(
     <useMyCompaniesContext.Provider
-      lists={[{ name: 'Lonely list', companies }]}
+      lists={[{ id: 'foo', name: 'Lonely list', companies }]}
     >
       <MyCompaniesTable />
     </useMyCompaniesContext.Provider>

--- a/src/dashboard/my-companies/__tests__/MyCompaniesTile.test.jsx
+++ b/src/dashboard/my-companies/__tests__/MyCompaniesTile.test.jsx
@@ -25,7 +25,7 @@ describe('My companies dashboard', () => {
   })
 
   test('One empty list', () => {
-    const wrapper = fixture([{ name: 'Foo', companies: [] }])
+    const wrapper = fixture([{ id: 'foo', name: 'Foo', companies: [] }])
     expect(wrapper.find(MyCompaniesTable)).toHaveLength(0)
     expect(wrapper.text()).toBe(
       'My Companies Lists' +
@@ -40,9 +40,9 @@ describe('My companies dashboard', () => {
   describe('Multiple lists', () => {
     test('first empty', () => {
       const wrapper = fixture([
-        { name: 'Foo', companies },
-        { name: 'Bar', companies: [] },
-        { name: 'Baz', companies },
+        { id: 'foo', name: 'Foo', companies },
+        { id: 'bar', name: 'Bar', companies: [] },
+        { id: 'baz', name: 'Baz', companies },
       ])
       expect(wrapper.find(MyCompaniesTable)).toHaveLength(0)
       expect(wrapper.text()).toBe(
@@ -60,9 +60,9 @@ describe('My companies dashboard', () => {
 
     test('first not empty', () => {
       const wrapper = fixture([
-        { name: 'Foo', companies },
-        { name: 'Bar', companies },
-        { name: 'Baz', companies },
+        { id: 'foo', name: 'Foo', companies },
+        { id: 'bar', name: 'Bar', companies },
+        { id: 'baz', name: 'Baz', companies },
       ])
       expect(wrapper.find(MyCompaniesTable)).toHaveLength(1)
     })

--- a/src/dashboard/my-companies/__tests__/MyCompaniesTile.test.jsx
+++ b/src/dashboard/my-companies/__tests__/MyCompaniesTile.test.jsx
@@ -30,7 +30,7 @@ describe('My companies dashboard', () => {
     expect(wrapper.text()).toBe(
       'My Companies Lists' +
         'Foo' +
-        'Edit lists' +
+        'Delete this list' +
         'You have not added any companies to your list.' +
         'You can add companies to this list from a company page, ' +
         'and only you can see this list.'
@@ -51,7 +51,7 @@ describe('My companies dashboard', () => {
           'Bar' +
           'Baz' +
           'Foo' +
-          'Edit lists' +
+          'Delete this list' +
           'You have not added any companies to your list.' +
           'You can add companies to this list from a company page, ' +
           'and only you can see this list.'

--- a/src/dashboard/my-companies/__tests__/useMyCompaniesContext.test.jsx
+++ b/src/dashboard/my-companies/__tests__/useMyCompaniesContext.test.jsx
@@ -9,7 +9,11 @@ import companies from '../../__fixtures__/companies'
 import { LIST_CHANGE, FILTER_CHANGE, ORDER_CHANGE } from '../constants'
 
 const initialState = {
-  lists: [{ name: 'Foo' }, { name: 'Bar' }, { name: 'Baz' }],
+  lists: [
+    { id: 'foo', name: 'Foo' },
+    { id: 'bar', name: 'Bar' },
+    { id: 'baz', name: 'Baz' },
+  ],
   selectedIdx: 0,
   sortBy: 'alphabetical',
   filter: 'foobarbaz',

--- a/src/dashboard/my-companies/useMyCompaniesContext.jsx
+++ b/src/dashboard/my-companies/useMyCompaniesContext.jsx
@@ -32,7 +32,7 @@ export const reducer = (state, { type, ...action }) => {
 
 // We are unpacking children here just to remove them from initialState.
 const useMyCompaniesContext = createUseContext(
-  ({ children, editListsLinkProps, ...rest }) => {
+  ({ children, deleteListPropsAccessor, ...rest }) => {
     const initialState = pick(rest, [
       'lists',
       'selectedIdx',
@@ -49,7 +49,7 @@ const useMyCompaniesContext = createUseContext(
     return {
       state,
       dispatch,
-      editListsLinkProps,
+      deleteListPropsAccessor,
     }
   }
 )

--- a/src/dashboard/my-companies/useMyCompaniesContext.jsx
+++ b/src/dashboard/my-companies/useMyCompaniesContext.jsx
@@ -1,5 +1,6 @@
 import { orderBy, pick } from 'lodash'
 import { useReducer } from 'react'
+import PropTypes from 'prop-types'
 import createUseContext from 'constate'
 import { FILTER_CHANGE, LIST_CHANGE, ORDER_CHANGE } from './constants'
 
@@ -53,5 +54,14 @@ const useMyCompaniesContext = createUseContext(
     }
   }
 )
+
+useMyCompaniesContext.Provider.propTypes = {
+  lists: PropTypes.arrayOf(
+    PropTypes.shape({
+      name: PropTypes.string.isRequired,
+      id: PropTypes.string.isRequired,
+    })
+  ),
+}
 
 export default useMyCompaniesContext

--- a/src/dashboard/my-companies/useMyCompaniesContext.jsx
+++ b/src/dashboard/my-companies/useMyCompaniesContext.jsx
@@ -55,11 +55,27 @@ const useMyCompaniesContext = createUseContext(
   }
 )
 
+const idNameShape = {
+  name: PropTypes.string.isRequired,
+  id: PropTypes.string.isRequired,
+}
+
 useMyCompaniesContext.Provider.propTypes = {
   lists: PropTypes.arrayOf(
     PropTypes.shape({
-      name: PropTypes.string.isRequired,
-      id: PropTypes.string.isRequired,
+      ...idNameShape,
+      companies: PropTypes.arrayOf(
+        PropTypes.shape({
+          company: PropTypes.shape({
+            ...idNameShape,
+          }).isRequired,
+          latestInteraction: PropTypes.shape({
+            id: PropTypes.string,
+            date: PropTypes.string,
+            subject: PropTypes.string,
+          }),
+        })
+      ),
     })
   ),
 }


### PR DESCRIPTION
# Change the label and behavior of the my companies _edit lists_ link

We decided that there's gonna be no _edit lists_ page and moved the functionality of removing a list to the dashboard. So now instead of the _edit list_ link to the right of the _companies list selector_, there will be a _delete this list_ link.

<img width="627" alt="Screen Shot 2019-10-21 at 1 00 00 PM" src="https://user-images.githubusercontent.com/2333157/67203350-c85a8c00-f402-11e9-9e95-21c676802581.png">
<img width="502" alt="Screen Shot 2019-10-21 at 12 59 37 PM" src="https://user-images.githubusercontent.com/2333157/67203351-c8f32280-f402-11e9-9551-59223b8eabdc.png">
