### PR TITLE
Refactor/collection item

### DIFF
--- a/src/collection-list/CollectionItem.jsx
+++ b/src/collection-list/CollectionItem.jsx
@@ -10,7 +10,16 @@ import {
   ItemMeta,
 } from './items'
 
-function CollectionItem({ headingUrl, headingText, badges, metadata }) {
+function CollectionItem({
+  itemId,
+  basePath,
+  subPath,
+  headingText,
+  badges,
+  metadata,
+}) {
+  const headingUrl = subPath ? basePath + itemId + subPath : basePath + itemId
+
   return (
     <Item>
       <CardHeader>
@@ -35,7 +44,9 @@ function CollectionItem({ headingUrl, headingText, badges, metadata }) {
 }
 
 CollectionItem.propTypes = {
-  headingUrl: PropTypes.string.isRequired,
+  itemId: PropTypes.string.isRequired,
+  basePath: PropTypes.string.isRequired,
+  subPath: PropTypes.string,
   headingText: PropTypes.string.isRequired,
   badges: PropTypes.array,
   metadata: PropTypes.array,
@@ -44,6 +55,7 @@ CollectionItem.propTypes = {
 CollectionItem.defaultProps = {
   badges: null,
   metadata: null,
+  subPath: null,
 }
 
 export default CollectionItem

--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -19,6 +19,8 @@ function CollectionList({
   next,
   profiles,
   apiEndpoint,
+  basePath,
+  subPath,
 }) {
   const pageLimit = getNumberParam(apiEndpoint, 'limit=')
 
@@ -38,13 +40,15 @@ function CollectionList({
       />
       {profiles
         .slice(0, pageLimit)
-        .map(({ companyId, headingUrl, headingText, badges, metadata }) => (
+        .map(({ itemId, headingText, badges, metadata }) => (
           <CollectionItem
-            key={companyId}
-            headingUrl={headingUrl}
+            key={itemId}
+            itemId={itemId}
             headingText={headingText}
             badges={badges}
             metadata={metadata}
+            basePath={basePath}
+            subPath={subPath}
           />
         ))}
       <CollectionPagination
@@ -67,6 +71,8 @@ CollectionList.propTypes = {
   previous: PropTypes.string,
   next: PropTypes.string,
   apiEndpoint: PropTypes.string.isRequired,
+  basePath: PropTypes.string.isRequired,
+  subPath: PropTypes.string,
 }
 
 CollectionList.defaultProps = {
@@ -75,6 +81,7 @@ CollectionList.defaultProps = {
   profiles: null,
   previous: null,
   next: null,
+  subPath: null,
 }
 
 export default CollectionList

--- a/src/collection-list/__fixtures__/capitalProfileCollectionList1.json
+++ b/src/collection-list/__fixtures__/capitalProfileCollectionList1.json
@@ -4,13 +4,14 @@
   "addItemUrl": "#",
   "downloadUrl": "#",
   "apiEndpoint": "http://localhost:8000/v4/large-investor-profile?limit=10",
+  "basePath": "/companies/",
+  "subPath": "/investments/large-capital-profile",
   "previous": null,
   "next": "http://localhost:8000/v4/large-investor-profile?limit=10&offset=10",
   "profiles": [
     {
       "headingText": "Mars Exports Ltd",
-      "companyId": "1",
-      "headingUrl": "#",
+      "itemId": "1",
       "metadata": [
         {
           "label": "Updated on",
@@ -23,8 +24,7 @@
     },
     {
       "headingText": "Stage One Boutique",
-      "companyId": "2",
-      "headingUrl": "#",
+      "itemId": "2",
       "metadata": [
         {
           "label": "Updated on",
@@ -37,8 +37,7 @@
     },
     {
       "headingText": "Onet Technologies",
-      "companyId": "3",
-      "headingUrl": "#",
+      "itemId": "3",
       "metadata": [
         {
           "label": "Updated on",
@@ -51,8 +50,7 @@
     },
     {
       "headingText": "Lambda plc",
-      "companyId": "4",
-      "headingUrl": "#",
+      "itemId": "4",
       "metadata": [
         {
           "label": "Updated on",
@@ -65,8 +63,7 @@
     },
     {
       "headingText": "One List Corp",
-      "companyId": "5",
-      "headingUrl": "#",
+      "itemId": "5",
       "metadata": [
         {
           "label": "Updated on",
@@ -79,8 +76,7 @@
     },
     {
       "headingText": "Angel syndicate",
-      "companyId": "6",
-      "headingUrl": "#",
+      "itemId": "6",
       "metadata": [
         {
           "label": "Updated on",
@@ -93,8 +89,7 @@
     },
     {
       "headingText": "Venus Ltd",
-      "companyId": "7",
-      "headingUrl": "#",
+      "itemId": "7",
       "metadata": [
         {
           "label": "Updated on",
@@ -107,8 +102,7 @@
     },
     {
       "headingText": "A1 BMW LTD",
-      "companyId": "8",
-      "headingUrl": "#",
+      "itemId": "8",
       "metadata": [
         {
           "label": "Updated on",
@@ -121,8 +115,7 @@
     },
     {
       "headingText": "Bargainworld",
-      "companyId": "9",
-      "headingUrl": "#",
+      "itemId": "9",
       "metadata": [
         {
           "label": "Updated on",
@@ -135,8 +128,7 @@
     },
     {
       "headingText": "JOHN LEWIS PLC",
-      "companyId": "10",
-      "headingUrl": "#",
+      "itemId": "10",
       "metadata": [
         {
           "label": "Updated on",

--- a/src/collection-list/__fixtures__/capitalProfileItem.json
+++ b/src/collection-list/__fixtures__/capitalProfileItem.json
@@ -1,6 +1,8 @@
 {
   "headerText": "Mars Exports Ltd",
-  "headerUrl": "#",
+  "itemId": "1",
+  "basePath": "/companies/",
+  "subPath": "/investments/large-capital-profile",
   "metadata": [
     {
       "label": "Updated on",

--- a/src/collection-list/__fixtures__/interactionItem.json
+++ b/src/collection-list/__fixtures__/interactionItem.json
@@ -1,6 +1,7 @@
 {
   "headerText": "Leadership Academy",
-  "headerUrl": "#",
+  "basePath": "/interactions/",
+  "itemId": "1",
   "metadata": [
     {
       "label": "Date",

--- a/src/collection-list/__stories__/CollectionList.stories.jsx
+++ b/src/collection-list/__stories__/CollectionList.stories.jsx
@@ -23,6 +23,8 @@ storiesOf('Collection', module).add('Collection', () => (
     previous={capitalProfileCollectionList1.previous}
     next={capitalProfileCollectionList1.next}
     apiEndpoint={capitalProfileCollectionList1.apiEndpoint}
+    basePath={capitalProfileCollectionList1.basePath}
+    subPath={capitalProfileCollectionList1.subPath}
   />
 ))
 
@@ -70,16 +72,6 @@ storiesOf('Collection', module).add(
   )
 )
 
-storiesOf('Collection', module).add('Capital Profile item', () => (
-  <CollectionItem
-    id={capitalProfileItem.id}
-    headingUrl={capitalProfileItem.headerUrl}
-    headingText={capitalProfileItem.headerText}
-    badges={capitalProfileItem.badges}
-    metadata={capitalProfileItem.metadata}
-  />
-))
-
 storiesOf('Collection', module).add('Collection Header', () => (
   <CollectionHeader
     totalItems={capitalProfileHeading.totalItems}
@@ -91,9 +83,10 @@ storiesOf('Collection', module).add('Collection Header', () => (
 
 storiesOf('Collection', module).add('Capital Profile item', () => (
   <CollectionItem
-    id={capitalProfileItem.id}
-    headingUrl={capitalProfileItem.headerUrl}
+    itemId={capitalProfileItem.itemId}
     headingText={capitalProfileItem.headerText}
+    basePath={capitalProfileItem.basePath}
+    subPath={capitalProfileItem.subPath}
     badges={capitalProfileItem.badges}
     metadata={capitalProfileItem.metadata}
   />
@@ -101,9 +94,10 @@ storiesOf('Collection', module).add('Capital Profile item', () => (
 
 storiesOf('Collection', module).add('Interaction item', () => (
   <CollectionItem
-    id={interactionItem.id}
-    headingUrl={interactionItem.headerUrl}
+    itemId={interactionItem.itemId}
     headingText={interactionItem.headerText}
+    basePath={interactionItem.basePath}
+    subPath={null}
     badges={interactionItem.badges}
     metadata={interactionItem.metadata}
   />

--- a/src/collection-list/__tests__/CollectionItem.test.jsx
+++ b/src/collection-list/__tests__/CollectionItem.test.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { mount } from 'enzyme'
 import CollectionItem from '../CollectionItem'
 import capitalProfileItem from '../__fixtures__/capitalProfileItem'
+import interactionItem from '../__fixtures__/interactionItem'
 
 describe('CollectionItem', () => {
   let wrapper
@@ -10,8 +11,10 @@ describe('CollectionItem', () => {
     beforeAll(() => {
       wrapper = mount(
         <CollectionItem
-          headingUrl={capitalProfileItem.headerUrl}
+          itemId={capitalProfileItem.itemId}
           headingText={capitalProfileItem.headerText}
+          basePath={capitalProfileItem.basePath}
+          subPath={capitalProfileItem.subPath}
           badges={capitalProfileItem.badges}
           metadata={capitalProfileItem.metadata}
         />
@@ -27,7 +30,9 @@ describe('CollectionItem', () => {
     })
 
     test('should render the headingUrl', () => {
-      expect(wrapper.find('a[href="#"]')).toHaveLength(1)
+      expect(
+        wrapper.find('a[href="/companies/1/investments/large-capital-profile"]')
+      ).toHaveLength(1)
     })
 
     test('should render the badge', () => {
@@ -52,8 +57,10 @@ describe('CollectionItem', () => {
     beforeAll(() => {
       wrapper = mount(
         <CollectionItem
-          headingUrl={capitalProfileItem.headerUrl}
-          headingText={capitalProfileItem.headerText}
+          itemId={interactionItem.itemId}
+          headingText={interactionItem.headerText}
+          basePath={interactionItem.basePath}
+          subPath={null}
         />
       )
     })
@@ -63,11 +70,11 @@ describe('CollectionItem', () => {
     })
 
     test('should render the headingText', () => {
-      expect(wrapper.find('h3').text()).toBe('Mars Exports Ltd')
+      expect(wrapper.find('h3').text()).toBe('Leadership Academy')
     })
 
-    test('should render the headingUrl', () => {
-      expect(wrapper.find('a[href="#"]')).toHaveLength(1)
+    test('should render the headingUrl without subPath', () => {
+      expect(wrapper.find('a[href="/interactions/1"]')).toHaveLength(1)
     })
 
     test('should not render the badge component', () => {

--- a/src/collection-list/__tests__/CollectionList.test.jsx
+++ b/src/collection-list/__tests__/CollectionList.test.jsx
@@ -18,6 +18,8 @@ describe('CollectionItem', () => {
           previous={capitalProfileCollectionList1.previous}
           next={capitalProfileCollectionList1.next}
           apiEndpoint={capitalProfileCollectionList1.apiEndpoint}
+          basePath={capitalProfileCollectionList1.basePath}
+          subPath={capitalProfileCollectionList1.subPath}
         />
       )
     })
@@ -39,6 +41,8 @@ describe('CollectionItem', () => {
           previous={capitalProfileCollectionList1.previous}
           next={capitalProfileCollectionList1.next}
           apiEndpoint="http://localhost:8000/v4/large-investor-profile"
+          basePath={capitalProfileCollectionList1.basePath}
+          subPath={capitalProfileCollectionList1.subPath}
         />
       )
     })


### PR DESCRIPTION
Refactor the CollectionItem component to generate its own headingUrl based on the itemId (also used for the key), the basePath and (optional) subPath. 

This improves the reusability of the component. 

No visible changes. 