### PR TITLE
feat: add isLoading spinner to CollectionList

### DIFF
--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
+import LoadingBox from '@govuk-react/loading-box'
 import getNumberParam from './getNumberParam'
 
 import {
@@ -21,13 +22,14 @@ function CollectionList({
   apiEndpoint,
   basePath,
   subPath,
+  isLoading,
 }) {
   const pageLimit = getNumberParam(apiEndpoint, 'limit=')
 
   const totalPages = Math.floor(totalItems / pageLimit) + 1
 
   return (
-    <>
+    <LoadingBox loading={isLoading}>
       <CollectionHeader
         totalItems={totalItems}
         itemName={itemName}
@@ -61,7 +63,7 @@ function CollectionList({
         apiEndpoint={apiEndpoint}
         pageLimit={pageLimit}
       />
-    </>
+    </LoadingBox>
   )
 }
 
@@ -76,6 +78,7 @@ CollectionList.propTypes = {
   apiEndpoint: PropTypes.string.isRequired,
   basePath: PropTypes.string.isRequired,
   subPath: PropTypes.string,
+  isLoading: PropTypes.bool.isRequired,
 }
 
 CollectionList.defaultProps = {

--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -78,7 +78,7 @@ CollectionList.propTypes = {
   apiEndpoint: PropTypes.string.isRequired,
   basePath: PropTypes.string.isRequired,
   subPath: PropTypes.string,
-  isLoading: PropTypes.bool.isRequired,
+  isLoading: PropTypes.bool,
 }
 
 CollectionList.defaultProps = {
@@ -88,6 +88,7 @@ CollectionList.defaultProps = {
   previous: null,
   next: null,
   subPath: null,
+  isLoading: false,
 }
 
 export default CollectionList

--- a/src/collection-list/__stories__/CollectionList.stories.jsx
+++ b/src/collection-list/__stories__/CollectionList.stories.jsx
@@ -25,6 +25,21 @@ storiesOf('Collection', module).add('Collection', () => (
     apiEndpoint={capitalProfileCollectionList1.apiEndpoint}
     basePath={capitalProfileCollectionList1.basePath}
     subPath={capitalProfileCollectionList1.subPath}
+    isLoading={false}
+  />
+))
+
+storiesOf('Collection', module).add('Collection - isLoading', () => (
+  <CollectionList
+    totalItems={capitalProfileCollectionList1.totalItems}
+    itemName={capitalProfileCollectionList1.itemName}
+    addItemUrl={capitalProfileCollectionList1.addItemUrl}
+    downloadUrl={capitalProfileCollectionList1.downloadUrl}
+    profiles={capitalProfileCollectionList1.profiles}
+    previous={capitalProfileCollectionList1.previous}
+    next={capitalProfileCollectionList1.next}
+    apiEndpoint={capitalProfileCollectionList1.apiEndpoint}
+    isLoading={true}
   />
 ))
 

--- a/src/collection-list/__tests__/CollectionList.test.jsx
+++ b/src/collection-list/__tests__/CollectionList.test.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { mount } from 'enzyme'
+import LoadingBox from '@govuk-react/loading-box'
 import CollectionList from '../CollectionList'
 import capitalProfileCollectionList1 from '../__fixtures__/capitalProfileCollectionList1'
 
@@ -20,12 +21,18 @@ describe('CollectionItem', () => {
           apiEndpoint={capitalProfileCollectionList1.apiEndpoint}
           basePath={capitalProfileCollectionList1.basePath}
           subPath={capitalProfileCollectionList1.subPath}
+          isLoading={false}
         />
       )
     })
 
     test('should render the component', () => {
       expect(wrapper.find(CollectionList).exists()).toBe(true)
+    })
+
+    test('the loading spinner is not displayed', () => {
+      const loader = wrapper.find(LoadingBox)
+      expect(loader.prop('loading')).toBe(false)
     })
   })
 
@@ -43,6 +50,7 @@ describe('CollectionItem', () => {
           apiEndpoint="http://localhost:8000/v4/large-investor-profile"
           basePath={capitalProfileCollectionList1.basePath}
           subPath={capitalProfileCollectionList1.subPath}
+          isLoading={false}
         />
       )
     })
@@ -53,6 +61,40 @@ describe('CollectionItem', () => {
 
     test('the page limit should default to 10', () => {
       expect(wrapper.find('h3')).toHaveLength(10)
+    })
+
+    test('the loading spinner is not displayed', () => {
+      const loader = wrapper.find(LoadingBox)
+      expect(loader.prop('loading')).toBe(false)
+    })
+  })
+
+  describe('when isLoading is set to true', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionList
+          totalItems={capitalProfileCollectionList1.totalItems}
+          itemName={capitalProfileCollectionList1.itemName}
+          addItemUrl={capitalProfileCollectionList1.addItemUrl}
+          downloadUrl={capitalProfileCollectionList1.downloadUrl}
+          profiles={capitalProfileCollectionList1.profiles}
+          previous={capitalProfileCollectionList1.previous}
+          next={capitalProfileCollectionList1.next}
+          apiEndpoint="http://localhost:8000/v4/large-investor-profile"
+          basePath={capitalProfileCollectionList1.basePath}
+          subPath={capitalProfileCollectionList1.subPath}
+          isLoading={true}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionList).exists()).toBe(true)
+    })
+
+    test('the loading spinner is displayed', () => {
+      const loader = wrapper.find(LoadingBox)
+      expect(loader.prop('loading')).toBe(true)
     })
   })
 })


### PR DESCRIPTION
Add a new `isLoading` prop to the collection list to show the `LoadingBox` while making async requests to get new data. 

I will build parent implementation component for the `CollectionList` that will handle all the requests in the frontend repo. 

![isLoading](https://user-images.githubusercontent.com/42253716/67291949-37ef7a80-f4da-11e9-8122-d1e63904812e.png)
