### PR TITLE
fix: Replace pluralise library with pluralize

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "govuk-colours": "^1.0.3",
     "lodash": "^4.17.11",
     "moment": "^2.24.0",
-    "pluralise": "^1.0.1",
+    "pluralize": "^8.0.0",
     "prop-types": "^15.7.2",
     "react-lines-ellipsis": "^0.14.1",
     "react-markdown": "^4.0.8",

--- a/src/activity-feed/ActivityFeedHeader.jsx
+++ b/src/activity-feed/ActivityFeedHeader.jsx
@@ -4,7 +4,7 @@ import Button from '@govuk-react/button'
 import { H2 } from '@govuk-react/heading'
 import styled from 'styled-components'
 import { SPACING, MEDIA_QUERIES } from '@govuk-react/constants'
-import pluralise from 'pluralise'
+import pluralize from 'pluralize'
 
 const HeaderSummary = styled('div')`
   display: flex;
@@ -61,12 +61,10 @@ export default class ActivityFeedHeader extends React.Component {
 
   render() {
     const { totalActivities, addContentText, addContentLink } = this.props
-    const headerText = pluralise.withCount(
-      totalActivities,
-      '% activity',
-      '% activities',
-      'Activities'
-    )
+    const headerText = totalActivities
+      ? pluralize('activity', totalActivities, true)
+      : 'Activities'
+
     const showAddContentButton = addContentText && addContentLink
 
     return (

--- a/src/address-search/usePostcodeLookup.js
+++ b/src/address-search/usePostcodeLookup.js
@@ -1,13 +1,9 @@
 import axios from 'axios'
-import pluralise from 'pluralise'
+import pluralize from 'pluralize'
 
 function usePostcodeLookup(apiEndpoint) {
   function createAddressCount(addresses) {
-    const addressCount = pluralise.withCount(
-      addresses.length,
-      '% address',
-      '% addresses'
-    )
+    const addressCount = pluralize('address', addresses.length, true)
     return {
       address1: `${addressCount} found`,
     }

--- a/src/collection-list/CollectionDownload.jsx
+++ b/src/collection-list/CollectionDownload.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
-import pluralise from 'pluralise'
+import pluralize from 'pluralize'
 import {
   SPACING,
   MEDIA_QUERIES,
@@ -46,8 +46,8 @@ const StyledButton = styled(Button)`
 `
 
 function CollectionDownload({ totalItems, itemName, downloadUrl }) {
-  const itemPlural = pluralise(2, `${itemName}`)
-  const itemPluralWithCount = pluralise.withCount(totalItems, `% ${itemName}`)
+  const itemPlural = pluralize.plural(itemName)
+  const itemPluralWithCount = pluralize(itemName, totalItems, true)
 
   const SingularText = `You can download this ${itemName}`
   const PluralText = `You can download these ${itemPluralWithCount}`

--- a/src/collection-list/CollectionHeader.jsx
+++ b/src/collection-list/CollectionHeader.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import PropTypes from 'prop-types'
 import Button from '@govuk-react/button'
 import styled from 'styled-components'
-import pluralise from 'pluralise'
+import pluralize from 'pluralize'
 import { H2 } from '@govuk-react/heading'
 import { BLACK, GREY_3 } from 'govuk-colours'
 import { SPACING, MEDIA_QUERIES, FONT_SIZE } from '@govuk-react/constants'
@@ -41,7 +41,7 @@ const StyledLink = styled.a`
 `
 
 function CollectionHeader({ totalItems, itemName, addItemUrl }) {
-  const headerText = pluralise.withCount(totalItems, `% ${itemName}`)
+  const headerText = pluralize(itemName, totalItems, true)
 
   return (
     <StyledSummary>

--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -33,11 +33,13 @@ function CollectionList({
         itemName={itemName}
         addItemUrl={addItemUrl}
       />
+
       <CollectionDownload
         totalItems={totalItems}
         itemName={itemName}
         downloadUrl={downloadUrl}
       />
+
       {profiles
         .slice(0, pageLimit)
         .map(({ itemId, headingText, badges, metadata }) => (
@@ -51,6 +53,7 @@ function CollectionList({
             subPath={subPath}
           />
         ))}
+
       <CollectionPagination
         totalPages={totalPages}
         previous={previous}

--- a/src/company-lists/DeleteCompanyListSection.jsx
+++ b/src/company-lists/DeleteCompanyListSection.jsx
@@ -8,7 +8,7 @@ import Link from '@govuk-react/link'
 import ListItem from '@govuk-react/list-item'
 import Paragraph from '@govuk-react/paragraph'
 import UnorderedList from '@govuk-react/unordered-list'
-import pluralise from 'pluralise'
+import pluralize from 'pluralize'
 
 import FormActions from '../forms/elements/FormActions'
 
@@ -18,11 +18,7 @@ const DeleteCompanyListSection = ({
   onDelete,
   returnUrl,
 }) => {
-  const companyCountText = pluralise.withCount(
-    companyList.item_count,
-    '% company',
-    '% companies'
-  )
+  const companyCountText = pluralize('company', companyList.item_count, true)
 
   return (
     <div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9942,10 +9942,10 @@ please-upgrade-node@^3.1.1:
   dependencies:
     semver-compare "^1.0.0"
 
-pluralise@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/pluralise/-/pluralise-1.0.1.tgz#c17a240ca8c6febb1439f7d2e78077defd128500"
-  integrity sha512-C2ddX33ihY6e3S7JYG8FspCf0o08D8tsXef2zcEx9geuX3vlOhkmUy6pXjRvmlVC60p7J5l3OxviKMFWLMs/0g==
+pluralize@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/pluralize/-/pluralize-8.0.0.tgz#1a6fa16a38d12a1901e0320fa017051c539ce3b1"
+  integrity sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA==
 
 pn@^1.1.0:
   version "1.1.0"


### PR DESCRIPTION
Replace library used to make plural strings based on a counter.

The new library requires less coding and is used also on the `data-hub-frontend`.