### PR TITLE
fix: checkbox boxsizing issue

### DIFF
--- a/src/activity-feed/filters/BasicActivityTypeFilter.jsx
+++ b/src/activity-feed/filters/BasicActivityTypeFilter.jsx
@@ -56,6 +56,7 @@ const StyledCheckbox = styled(Checkbox)`
       width: 12px;
       height: 6px;
       border-width: 0 0 ${BORDER_WIDTH_MOBILE} ${BORDER_WIDTH_MOBILE};
+      box-sizing: unset;
     }
   }
 


### PR DESCRIPTION
in DH there's a global selector `*::after` that sets all the box-sizing to border box, which renders the  output below.
<img width="538" alt="Screenshot 2019-10-23 at 16 30 30" src="https://user-images.githubusercontent.com/1295319/67409431-7a848600-f5b2-11e9-8acd-60fa83c33a08.png">
