### PR TITLE
fix: count only filtered activities

### DIFF
--- a/src/activity-feed/ActivityFeed.jsx
+++ b/src/activity-feed/ActivityFeed.jsx
@@ -1,3 +1,4 @@
+import { intersection } from 'lodash'
 import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
@@ -32,7 +33,6 @@ export default class ActivityFeed extends React.Component {
     isLoading: PropTypes.bool,
     addContentText: PropTypes.string,
     addContentLink: PropTypes.string,
-    totalActivities: PropTypes.number,
   }
 
   static defaultProps = {
@@ -43,7 +43,6 @@ export default class ActivityFeed extends React.Component {
     isLoading: false,
     addContentText: null,
     addContentLink: null,
-    totalActivities: 0,
   }
 
   constructor(props) {
@@ -61,9 +60,10 @@ export default class ActivityFeed extends React.Component {
 
   onActivityTypeFilterChange(e) {
     const value = e.target.value.split(',')
+    const filteredActivity = e.target.value === 'all' ? [] : value
 
     this.setState({
-      filteredActivity: e.target.value === 'all' ? [] : value,
+      filteredActivity,
     })
   }
 
@@ -81,7 +81,6 @@ export default class ActivityFeed extends React.Component {
       isLoading,
       addContentText,
       addContentLink,
-      totalActivities,
       children,
     } = this.props
     const {
@@ -91,10 +90,18 @@ export default class ActivityFeed extends React.Component {
       showDetails,
     } = this.state
 
+    const count = activities.filter((activity) => {
+      if (filteredActivity.length) {
+        return intersection(activity.object.type, filteredActivity).length
+      } else {
+        return true
+      }
+    }).length
+
     return (
       <ActivityFeedContainer>
         <ActivityFeedHeader
-          totalActivities={totalActivities}
+          totalActivities={count}
           addContentText={addContentText}
           addContentLink={addContentLink}
         />

--- a/src/activity-feed/ActivityFeedApp.jsx
+++ b/src/activity-feed/ActivityFeedApp.jsx
@@ -91,14 +91,12 @@ export default class ActivityFeedApp extends React.Component {
   }
 
   render() {
-    const { activities, isLoading, hasMore, total, error } = this.state
+    const { activities, isLoading, hasMore, error } = this.state
     const { addContentText, addContentLink, render } = this.props
 
     const isEmptyFeed = activities.length === 0 && !hasMore
-
     return (
       <ActivityFeed
-        totalActivities={total}
         addContentText={addContentText}
         addContentLink={addContentLink}
         activities={activities}


### PR DESCRIPTION
currently it's showing the count for all activities coming from the API, we need to display only the count for the activities in view. (This creates confusion when a large number of activities are present) 
<img width="615" alt="Screenshot 2019-10-24 at 11 44 35" src="https://user-images.githubusercontent.com/1295319/67478344-c0ddf180-f653-11e9-8071-200b31b6dbe2.png">
