### PR TITLE
feat: Add Metadata component

### DIFF
--- a/src/index.jsx
+++ b/src/index.jsx
@@ -59,5 +59,9 @@ export { default as FieldRadios } from './forms/elements/FieldRadios'
 export { default as FieldSelect } from './forms/elements/FieldSelect'
 export { default as FieldUneditable } from './forms/elements/FieldUneditable'
 
+// Metadata
+export { default as Metadata } from './metadata/Metadata'
+export { default as MetadataItem } from './metadata/MetadataItem'
+
 // Status message
 export { default as StatusMessage } from './status-message/StatusMessage'

--- a/src/metadata/Metadata.jsx
+++ b/src/metadata/Metadata.jsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import { FONT_SIZE, SPACING } from '@govuk-react/constants'
+
+import MetadataItem from './MetadataItem'
+
+const StyledMetadataWrapper = styled('div')`
+  font-size: ${FONT_SIZE.SIZE_16};
+  line-height: ${FONT_SIZE.SIZE_27};
+  display: grid;
+
+  & > * {
+    margin-bottom: ${SPACING.SCALE_1};
+  }
+`
+
+const Metadata = ({ rows }) =>
+  rows && (
+    <StyledMetadataWrapper>
+      {rows.map(({ label, value }) => (
+        <MetadataItem key={label} label={label}>
+          {value}
+        </MetadataItem>
+      ))}
+    </StyledMetadataWrapper>
+  )
+
+Metadata.propTypes = {
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      label: PropTypes.node,
+      value: PropTypes.node,
+    })
+  ),
+}
+
+Metadata.defaultProps = {
+  children: null,
+}
+
+export default Metadata

--- a/src/metadata/MetadataItem.jsx
+++ b/src/metadata/MetadataItem.jsx
@@ -1,0 +1,31 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import { BLACK, GREY_1 } from 'govuk-colours'
+
+const StyledMetaWrapper = styled('div')`
+  color: ${BLACK};
+`
+
+const StyledItemLabel = styled('span')`
+  color: ${GREY_1};
+`
+
+function MetadataItem({ label, children }) {
+  return (
+    <StyledMetaWrapper>
+      {label && <StyledItemLabel>{label}</StyledItemLabel>} {children}
+    </StyledMetaWrapper>
+  )
+}
+
+MetadataItem.propTypes = {
+  label: PropTypes.string,
+  children: PropTypes.node.isRequired,
+}
+
+MetadataItem.defaultProps = {
+  label: null,
+}
+
+export default MetadataItem

--- a/src/metadata/__stories__/Metadata.stories.jsx
+++ b/src/metadata/__stories__/Metadata.stories.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+import Link from '@govuk-react/link'
+
+import Metadata from '../Metadata'
+
+const stories = storiesOf('Metadata', module)
+
+const metadata = [
+  { label: 'Updated on', value: '5 September 2019' },
+  { label: 'Sector', value: 'Environment' },
+  {
+    label: 'Parent company',
+    value: <Link href="http://example.com">E-corp LTD</Link>,
+  },
+]
+
+stories.add('Default', () => <Metadata rows={metadata} />)

--- a/src/metadata/__tests__/Metadata.test.jsx
+++ b/src/metadata/__tests__/Metadata.test.jsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import { mount } from 'enzyme'
+
+import Link from '@govuk-react/link'
+import Metadata from '../Metadata'
+
+describe('Metadata', () => {
+  let wrapper
+
+  describe('when "rows" prop was passed with no values', () => {
+    beforeAll(() => {
+      wrapper = mount(<Metadata rows={null} />)
+    })
+
+    test('should not render anything', () => {
+      expect(wrapper.html()).toEqual(null)
+    })
+  })
+
+  describe('when a "rows" prop is passed with values', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <Metadata
+          rows={[
+            { label: 'Updated on', value: '5 September 2019' },
+            {
+              label: 'Parent company',
+              value: <Link href="http://example.com">E-corp LTD</Link>,
+            },
+          ]}
+        />
+      )
+    })
+
+    test('should render all metadata items', () => {
+      expect(wrapper.text()).toContain(
+        'Updated on 5 September 2019Parent company E-corp LTD'
+      )
+    })
+  })
+})


### PR DESCRIPTION
Add component for metadata which will be used on collection pages, activity feed and in a few more places.

![image](https://user-images.githubusercontent.com/4199239/67687229-eb9bb300-f98f-11e9-8697-c5e6e4aeec78.png)