### PR TITLE
feat: Add an option to choose when a form is scrolling to the top

### DIFF
--- a/src/forms/elements/Form.jsx
+++ b/src/forms/elements/Form.jsx
@@ -4,16 +4,15 @@ import LoadingBox from '@govuk-react/loading-box'
 
 import useFormContext from '../hooks/useFormContext'
 
-function Form(props) {
-  const { initialValues, initialStep, onSubmit } = props
-
+function Form({ initialValues, initialStep, onSubmit, scrollToTop, children }) {
   return (
     <useFormContext.Provider
       initialValues={initialValues}
       initialStep={initialStep}
       onSubmit={onSubmit}
+      scrollToTop={scrollToTop}
     >
-      <FormWrapper {...props} />
+      <FormWrapper>{children}</FormWrapper>
     </useFormContext.Provider>
   )
 }
@@ -22,6 +21,7 @@ Form.propTypes = {
   initialValues: PropTypes.shape({}),
   initialStep: PropTypes.number,
   onSubmit: PropTypes.func,
+  scrollToTop: PropTypes.bool,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 }
 
@@ -29,12 +29,12 @@ Form.defaultProps = {
   initialValues: {},
   initialStep: 0,
   onSubmit: null,
+  scrollToTop: true,
   children: null,
 }
 
-function FormWrapper(props) {
-  const { children, ...rest } = props
-  const formContextProps = useFormContext(rest)
+function FormWrapper({ children }) {
+  const formContextProps = useFormContext()
 
   const renderChildren = () => {
     if (typeof children === 'function') {

--- a/src/forms/hooks/__tests__/useForm.test.jsx
+++ b/src/forms/hooks/__tests__/useForm.test.jsx
@@ -614,6 +614,21 @@ describe('useForm', () => {
     })
   })
 
+  describe('when goForward() is called but "scrollToTop" is set to false', () => {
+    beforeAll(async () => {
+      const hook = renderHook(() => useForm({ scrollToTop: false }))
+
+      await act(async () => {
+        window.scrollTo = jest.fn()
+        hook.result.current.goForward()
+      })
+    })
+
+    test('should not scroll to the top of the page', () => {
+      expect(window.scrollTo).not.toHaveBeenCalled()
+    })
+  })
+
   describe('when goBack() is called', () => {
     beforeAll(async () => {
       const hook = renderHook(() => useForm({ initialStep: 1 }))

--- a/src/forms/hooks/useForm.js
+++ b/src/forms/hooks/useForm.js
@@ -6,6 +6,7 @@ function useForm({
   initialValues = {},
   initialStep = 0,
   onSubmit = null,
+  scrollToTop = true,
 } = {}) {
   const [values, setValues] = useState(initialValues)
   const [touched, setTouched] = useState({})
@@ -45,7 +46,9 @@ function useForm({
   }, [redirectUrl])
 
   useDeepCompareEffect(() => {
-    window.scrollTo(0, 0)
+    if (scrollToTop) {
+      window.scrollTo(0, 0)
+    }
   }, [currentStep, errors])
 
   const getFieldState = (name) => {


### PR DESCRIPTION
In some cases we don't want the page to scroll when a form is submitted.