### PR TITLE
feat: Add interaction button to table cell

### DIFF
--- a/src/dashboard/__stories__/DashboardSection.stories.jsx
+++ b/src/dashboard/__stories__/DashboardSection.stories.jsx
@@ -21,6 +21,9 @@ storiesOf('Dashboard')
   .add('One full list', () => (
     <WithData
       deleteListPropsAccessor={({ id }) => ({ href: id })}
+      addInteractionPropsAccessor={(company) => ({
+        href: `/companies/${company.id}/interactions/create`,
+      })}
       lists={[{ id: 'foo', name: 'Foo', companies: allCompanies }]}
     />
   ))
@@ -37,6 +40,9 @@ storiesOf('Dashboard')
   .add('Three lists, first with single company', () => (
     <WithData
       deleteListPropsAccessor={({ id }) => ({ href: id })}
+      addInteractionPropsAccessor={(company) => ({
+        href: `/companies/${company.id}/interactions/create`,
+      })}
       lists={[
         { id: 'foo', name: 'Foo', companies: allCompanies },
         { id: 'bar', name: 'Bar', companies: allCompanies.slice(1, 2) },
@@ -47,6 +53,9 @@ storiesOf('Dashboard')
   .add('Three company lists', () => (
     <WithData
       deleteListPropsAccessor={({ id }) => ({ href: id })}
+      addInteractionPropsAccessor={(company) => ({
+        href: `/companies/${company.id}/interactions/create`,
+      })}
       lists={[
         {
           id: 'foo',

--- a/src/dashboard/my-companies/MyCompaniesTable.jsx
+++ b/src/dashboard/my-companies/MyCompaniesTable.jsx
@@ -6,8 +6,9 @@ import LinesEllipsis from 'react-lines-ellipsis'
 import { typography } from '@govuk-react/lib'
 import Table from '@govuk-react/table'
 import Link from '@govuk-react/link'
-import { GREY_1 } from 'govuk-colours'
+import { GREY_1, GREY_3, TEXT_COLOUR } from 'govuk-colours'
 import { MEDIA_QUERIES } from '@govuk-react/constants'
+import Button from '@govuk-react/button'
 import useMyCompaniesContext from './useMyCompaniesContext'
 import Filters from './MyCompaniesFilters'
 
@@ -21,9 +22,17 @@ const StyledCellHeader = styled(Table.CellHeader)(
   }
 )
 
+const StyledButtonTableCell = styled(Table.CellHeader)`
+  white-space: nowrap;
+`
+
 const StyledDateCell = styled(Table.Cell)(typography.font({ size: 14 }), {
   color: GREY_1,
 })
+
+const StyledLink = styled.a`
+  margin-bottom: 0;
+`
 
 function sortCompanies(companies, sortType) {
   const sort = {
@@ -52,7 +61,9 @@ const filterCompanyName = (companies, filterText) =>
 function MyCompaniesTable() {
   const {
     state: { lists, selectedIdx, sortBy, filter },
+    addInteractionPropsAccessor = () => ({}),
   } = useMyCompaniesContext()
+
   const list = lists[selectedIdx]
   const filteredSortedCompanies = sortCompanies(
     filterCompanyName(list.companies, filter),
@@ -63,7 +74,7 @@ function MyCompaniesTable() {
     <Table.Row>
       <StyledCellHeader>Company name</StyledCellHeader>
       <StyledCellHeader>Last interaction</StyledCellHeader>
-      <StyledCellHeader>&nbsp;</StyledCellHeader>
+      <StyledCellHeader colSpan="2">&nbsp;</StyledCellHeader>
     </Table.Row>
   )
 
@@ -86,7 +97,7 @@ function MyCompaniesTable() {
             ? moment(latestInteraction.date).format('D MMM YYYY')
             : '-'}
         </StyledDateCell>
-        <Table.Cell setWidth="60%">
+        <Table.Cell setWidth="50%">
           {latestInteraction.id ? (
             <Link href={`interactions/${latestInteraction.id}`}>
               <LinesEllipsis
@@ -101,6 +112,16 @@ function MyCompaniesTable() {
             latestInteraction.subject
           )}
         </Table.Cell>
+        <StyledButtonTableCell>
+          <Button
+            as={StyledLink}
+            buttonColour={GREY_3}
+            buttonTextColour={TEXT_COLOUR}
+            {...addInteractionPropsAccessor(company)}
+          >
+            Add interaction
+          </Button>
+        </StyledButtonTableCell>
       </Table.Row>
     )
   })

--- a/src/dashboard/my-companies/__tests__/MyCompaniesTable.test.jsx
+++ b/src/dashboard/my-companies/__tests__/MyCompaniesTable.test.jsx
@@ -52,14 +52,14 @@ describe('MyCompaniesTable', () => {
 
     test('Should display a single row', () => {
       expect(getTableRowTexts(wrapper)).toEqual([
-        'Company A foo6 Jan 2019Interaction A',
+        'Company A foo6 Jan 2019Interaction AAdd interaction',
       ])
     })
 
     test('Should not display filters', () => {
       expect(wrapper.find(MyCompaniesFilters)).toHaveLength(0)
       expect(wrapper.text()).toBe(
-        'Company nameLast interaction Company A foo6 Jan 2019Interaction A'
+        'Company nameLast interaction Company A foo6 Jan 2019Interaction AAdd interaction'
       )
     })
   })
@@ -73,27 +73,27 @@ describe('MyCompaniesTable', () => {
 
       test('Should order by recent interaction by default', () => {
         expect(getTableRowTexts(wrapper)).toEqual([
-          'Company A foo6 Jan 2019Interaction A',
-          'Company C foooo5 Jan 2019Interaction C',
-          'Company B fooo4 Jan 2019Interaction B',
+          'Company A foo6 Jan 2019Interaction AAdd interaction',
+          'Company C foooo5 Jan 2019Interaction CAdd interaction',
+          'Company B fooo4 Jan 2019Interaction BAdd interaction',
         ])
       })
 
       test('Should reorder on selecting the least recent order', () => {
         changeSelectAndUpdate(wrapper, 'Least recent interaction')
         expect(getTableRowTexts(wrapper)).toEqual([
-          'Company B fooo4 Jan 2019Interaction B',
-          'Company C foooo5 Jan 2019Interaction C',
-          'Company A foo6 Jan 2019Interaction A',
+          'Company B fooo4 Jan 2019Interaction BAdd interaction',
+          'Company C foooo5 Jan 2019Interaction CAdd interaction',
+          'Company A foo6 Jan 2019Interaction AAdd interaction',
         ])
       })
 
       test('Should reorder on selecting alphabetical sort option', () => {
         changeSelectAndUpdate(wrapper, 'Company name A-Z')
         expect(getTableRowTexts(wrapper)).toEqual([
-          'Company A foo6 Jan 2019Interaction A',
-          'Company B fooo4 Jan 2019Interaction B',
-          'Company C foooo5 Jan 2019Interaction C',
+          'Company A foo6 Jan 2019Interaction AAdd interaction',
+          'Company B fooo4 Jan 2019Interaction BAdd interaction',
+          'Company C foooo5 Jan 2019Interaction CAdd interaction',
         ])
       })
     })
@@ -103,18 +103,18 @@ describe('MyCompaniesTable', () => {
 
       test('Should not apply any filters by default', () => {
         expect(getTableRowTexts(wrapper)).toEqual([
-          'Company A foo6 Jan 2019Interaction A',
-          'Company C foooo5 Jan 2019Interaction C',
-          'Company B fooo4 Jan 2019Interaction B',
+          'Company A foo6 Jan 2019Interaction AAdd interaction',
+          'Company C foooo5 Jan 2019Interaction CAdd interaction',
+          'Company B fooo4 Jan 2019Interaction BAdd interaction',
         ])
       })
 
       test('Should apply filters on filter input change', () => {
         changeAndUpdate(wrapper.find('input'), 'foo')
         expect(getTableRowTexts(wrapper)).toEqual([
-          'Company A foo6 Jan 2019Interaction A',
-          'Company C foooo5 Jan 2019Interaction C',
-          'Company B fooo4 Jan 2019Interaction B',
+          'Company A foo6 Jan 2019Interaction AAdd interaction',
+          'Company C foooo5 Jan 2019Interaction CAdd interaction',
+          'Company B fooo4 Jan 2019Interaction BAdd interaction',
         ])
       })
     })

--- a/src/dashboard/my-companies/useMyCompaniesContext.jsx
+++ b/src/dashboard/my-companies/useMyCompaniesContext.jsx
@@ -33,7 +33,12 @@ export const reducer = (state, { type, ...action }) => {
 
 // We are unpacking children here just to remove them from initialState.
 const useMyCompaniesContext = createUseContext(
-  ({ children, deleteListPropsAccessor, ...rest }) => {
+  ({
+    children,
+    deleteListPropsAccessor,
+    addInteractionPropsAccessor,
+    ...rest
+  }) => {
     const initialState = pick(rest, [
       'lists',
       'selectedIdx',
@@ -51,6 +56,7 @@ const useMyCompaniesContext = createUseContext(
       state,
       dispatch,
       deleteListPropsAccessor,
+      addInteractionPropsAccessor,
     }
   }
 )


### PR DESCRIPTION
## Description
Users need be able to add an interaction to a company directly from the homepage. I have added an "add interaction" button against each company listed in the company list table, each button will send the user to the "add interaction" flow related to the company.

## Screenshot
![Screenshot 2019-11-22 at 17 18 04](https://user-images.githubusercontent.com/10154302/69446429-4ab0d580-0d4c-11ea-863b-c2a61dca3c67.png)
