### PR TITLE
fix: Hide the DnB Hierarchical filter when there are no subsidiaries

### DIFF
--- a/src/activity-feed/ActivityFeed.jsx
+++ b/src/activity-feed/ActivityFeed.jsx
@@ -36,7 +36,7 @@ export default class ActivityFeed extends React.Component {
     contentLink: PropTypes.string,
     totalActivities: PropTypes.number,
     isGlobalUltimate: PropTypes.bool,
-    dnbHierachyCount: PropTypes.number,
+    dnbHierarchyCount: PropTypes.number,
     isTypeFilterFlagEnabled: PropTypes.bool,
     isGlobalUltimateFlagEnabled: PropTypes.bool,
   }
@@ -53,7 +53,7 @@ export default class ActivityFeed extends React.Component {
     contentLink: null,
     totalActivities: 0,
     isGlobalUltimate: false,
-    dnbHierachyCount: null,
+    dnbHierarchyCount: null,
     isTypeFilterFlagEnabled: false,
     isGlobalUltimateFlagEnabled: false,
   }
@@ -134,7 +134,7 @@ export default class ActivityFeed extends React.Component {
       children,
       totalActivities,
       isGlobalUltimate,
-      dnbHierachyCount,
+      dnbHierarchyCount,
       isTypeFilterFlagEnabled,
       isGlobalUltimateFlagEnabled,
     } = this.props
@@ -156,7 +156,7 @@ export default class ActivityFeed extends React.Component {
             onActivityTypeFilterChange={this.onActivityTypeFilterChange}
             showActivitiesFromAllCompanies={this.showActivitiesFromAllCompanies}
             isGlobalUltimate={isGlobalUltimate}
-            dnbHierachyCount={dnbHierachyCount}
+            dnbHierarchyCount={dnbHierarchyCount}
             isTypeFilterFlagEnabled={isTypeFilterFlagEnabled}
             isGlobalUltimateFlagEnabled={isGlobalUltimateFlagEnabled}
           />

--- a/src/activity-feed/ActivityFeedApp.jsx
+++ b/src/activity-feed/ActivityFeedApp.jsx
@@ -16,7 +16,7 @@ export default class ActivityFeedApp extends React.Component {
     activityTypeFilters: PropTypes.object,
     apiEndpoint: PropTypes.string.isRequired,
     isGlobalUltimate: PropTypes.bool,
-    dnbHierachyCount: PropTypes.number,
+    dnbHierarchyCount: PropTypes.number,
     isTypeFilterFlagEnabled: PropTypes.bool,
     isGlobalUltimateFlagEnabled: PropTypes.bool,
   }
@@ -27,7 +27,7 @@ export default class ActivityFeedApp extends React.Component {
     contentLink: null,
     contentText: null,
     isGlobalUltimate: false,
-    dnbHierachyCount: null,
+    dnbHierarchyCount: null,
     isTypeFilterFlagEnabled: false,
     isGlobalUltimateFlagEnabled: false,
   }
@@ -134,7 +134,7 @@ export default class ActivityFeedApp extends React.Component {
       contentText,
       contentLink,
       isGlobalUltimate,
-      dnbHierachyCount,
+      dnbHierarchyCount,
       isTypeFilterFlagEnabled,
       isGlobalUltimateFlagEnabled,
     } = this.props
@@ -152,7 +152,7 @@ export default class ActivityFeedApp extends React.Component {
         sendQueryParams={this.setQueryParams}
         totalActivities={total}
         isGlobalUltimate={isGlobalUltimate}
-        dnbHierachyCount={dnbHierachyCount}
+        dnbHierarchyCount={dnbHierarchyCount}
         isTypeFilterFlagEnabled={isTypeFilterFlagEnabled}
         isGlobalUltimateFlagEnabled={isGlobalUltimateFlagEnabled}
       >

--- a/src/activity-feed/ActivityFeedFilters.jsx
+++ b/src/activity-feed/ActivityFeedFilters.jsx
@@ -39,21 +39,22 @@ const ActivityFeedFilters = ({
   onActivityTypeFilterChange,
   showActivitiesFromAllCompanies,
   isGlobalUltimate,
-  dnbHierachyCount,
+  dnbHierarchyCount,
   isGlobalUltimateFlagEnabled,
   isTypeFilterFlagEnabled,
 }) => {
-  const showUltimateHQFilter = isGlobalUltimate && isGlobalUltimateFlagEnabled
+  const isGlobalAndEnabled = isGlobalUltimate && isGlobalUltimateFlagEnabled
+  const showDnbHeirarchyFilter = isGlobalAndEnabled && dnbHierarchyCount > 1
   return (
     <ActivityFeedFiltersRow>
       <StyledTitle>Filter by</StyledTitle>
-      {showUltimateHQFilter && (
+      {showDnbHeirarchyFilter && (
         <StyledCheckboxContainer>
           <ActivityFeedCheckbox
             name="ultimateHQSubsidiariesFilter"
             onChange={showActivitiesFromAllCompanies}
           >
-            Activity across all {dnbHierachyCount} companies
+            Activity across all {dnbHierarchyCount} companies
           </ActivityFeedCheckbox>
         </StyledCheckboxContainer>
       )}
@@ -73,14 +74,14 @@ ActivityFeedFilters.propTypes = {
   activityTypeFilter: PropTypes.string.isRequired,
   onActivityTypeFilterChange: PropTypes.func.isRequired,
   showActivitiesFromAllCompanies: PropTypes.func.isRequired,
-  dnbHierachyCount: PropTypes.number,
+  dnbHierarchyCount: PropTypes.number,
   isGlobalUltimate: PropTypes.bool.isRequired,
   isGlobalUltimateFlagEnabled: PropTypes.bool.isRequired,
   isTypeFilterFlagEnabled: PropTypes.bool.isRequired,
 }
 
 ActivityFeedFilters.defaultProps = {
-  dnbHierachyCount: null,
+  dnbHierarchyCount: null,
 }
 
 export default ActivityFeedFilters

--- a/src/activity-feed/__stories__/ActivityFeed.stories.jsx
+++ b/src/activity-feed/__stories__/ActivityFeed.stories.jsx
@@ -159,7 +159,7 @@ class ActivityFeedDemoApp extends React.Component {
           isLoading={isLoading}
           contentText="Add interaction"
           contentLink="/companies/3335a773-a098-e211-a939-e4115bead28a/interactions/create"
-          dnbHierachyCount={8}
+          dnbHierarchyCount={8}
           isGlobalUltimate={true}
           isTypeFilterFlagEnabled={true}
           isGlobalUltimateFlagEnabled={true}

--- a/src/activity-feed/__tests__/ActivityFeed.test.jsx
+++ b/src/activity-feed/__tests__/ActivityFeed.test.jsx
@@ -210,7 +210,7 @@ describe('ActivityFeed', () => {
           hasMore={true}
           totalActivities={activities.length}
           activityTypeFilters={ACTIVITY_TYPE_FILTERS}
-          dnbHierachyCount={3}
+          dnbHierarchyCount={3}
           isTypeFilterFlagEnabled={true}
           isGlobalUltimateFlagEnabled={true}
         />
@@ -298,7 +298,7 @@ describe('ActivityFeed', () => {
           activities={[]}
           sendQueryParams={sendQueryParamsSpy}
           activityTypeFilters={ACTIVITY_TYPE_FILTERS}
-          dnbHierachyCount={3}
+          dnbHierarchyCount={3}
           isGlobalUltimate={true}
           isTypeFilterFlagEnabled={true}
           isGlobalUltimateFlagEnabled={true}

--- a/src/activity-feed/__tests__/ActivityFeedFilters.test.jsx
+++ b/src/activity-feed/__tests__/ActivityFeedFilters.test.jsx
@@ -33,7 +33,7 @@ describe('ActivityFeedFilters', () => {
           activityTypeFilter=""
           onActivityTypeFilterChange={() => {}}
           showActivitiesFromAllCompanies={() => {}}
-          dnbHierachyCount={null}
+          dnbHierarchyCount={null}
           isGlobalUltimate={false}
           isGlobalUltimateFlagEnabled={false}
           isTypeFilterFlagEnabled={false}
@@ -55,7 +55,7 @@ describe('ActivityFeedFilters', () => {
           activityTypeFilter={activityTypeFilter}
           onActivityTypeFilterChange={() => {}}
           showActivitiesFromAllCompanies={() => {}}
-          dnbHierachyCount={3}
+          dnbHierarchyCount={3}
           isGlobalUltimate={true}
           isGlobalUltimateFlagEnabled={true}
           isTypeFilterFlagEnabled={true}


### PR DESCRIPTION
## Hide the DnB hierarchy filter when there are no subsidiaries
![activity-across-1-companies](https://user-images.githubusercontent.com/964268/70211939-41e9d780-172e-11ea-9848-a6e949700b0f.png)

