### PR TITLE
feat: hide collectionItem metadata behind details if > 4

### DIFF
--- a/src/collection-list/CollectionItem.jsx
+++ b/src/collection-list/CollectionItem.jsx
@@ -6,6 +6,7 @@ import { H3 } from '@govuk-react/heading'
 import Link from '@govuk-react/link'
 import { HEADING_SIZES, SPACING } from '@govuk-react/constants'
 import { GREY_2 } from 'govuk-colours'
+import Details from '@govuk-react/details'
 
 import Metadata from '../metadata/Metadata'
 import Badge from '../badge/Badge'
@@ -46,13 +47,20 @@ const StyledSubheading = styled('h4')`
   margin: -${SPACING.SCALE_3} 0 ${SPACING.SCALE_2} 0;
 `
 
+const StyledDetails = styled(Details)`
+  margin: 50px 0 0 0;
+`
+
 function CollectionItem({
   headingUrl,
   headingText,
   subheading,
   badges,
   metadata,
+  type,
 }) {
+  const summaryMessage = type ? `View ${type} details` : 'View details'
+
   return (
     <ItemWrapper>
       {badges && (
@@ -73,7 +81,15 @@ function CollectionItem({
 
       <StyledSubheading>{subheading}</StyledSubheading>
 
-      <Metadata rows={metadata} />
+      {metadata && metadata.length > 4 ? (
+        <>
+          <StyledDetails summary={summaryMessage}>
+            <Metadata rows={metadata} />
+          </StyledDetails>
+        </>
+      ) : (
+        <Metadata rows={metadata} />
+      )}
     </ItemWrapper>
   )
 }
@@ -89,6 +105,7 @@ CollectionItem.propTypes = {
       value: PropTypes.node.isRequired,
     })
   ),
+  type: PropTypes.string,
 }
 
 CollectionItem.defaultProps = {
@@ -96,6 +113,7 @@ CollectionItem.defaultProps = {
   subheading: null,
   metadata: null,
   headingUrl: null,
+  type: null,
 }
 
 export default CollectionItem

--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -34,7 +34,7 @@ function CollectionList({
       />
 
       {items.map(
-        ({ headingText, headingUrl, subheading, badges, metadata }) => (
+        ({ headingText, headingUrl, subheading, badges, metadata, type }) => (
           <CollectionItem
             key={headingText + headingUrl}
             headingUrl={headingUrl}
@@ -42,6 +42,7 @@ function CollectionList({
             subheading={subheading}
             badges={badges}
             metadata={metadata}
+            type={type}
           />
         )
       )}

--- a/src/collection-list/__stories__/CollectionItem.stories.jsx
+++ b/src/collection-list/__stories__/CollectionItem.stories.jsx
@@ -13,7 +13,7 @@ collectionStories.add('Capital Profile item', () => (
 ))
 
 collectionStories.add('Interaction item', () => (
-  <CollectionItem {...interactionItem} />
+  <CollectionItem {...interactionItem} type="interaction" />
 ))
 
 collectionStories.add('Item without link', () => (

--- a/src/collection-list/__tests__/CollectionItem.test.jsx
+++ b/src/collection-list/__tests__/CollectionItem.test.jsx
@@ -7,6 +7,7 @@ import Badge from '../../badge/Badge'
 import MetadataItem from '../../metadata/MetadataItem'
 
 import capitalProfileItem from '../__fixtures__/capitalProfileItem'
+import interactionItem from '../__fixtures__/interactionItem'
 
 describe('CollectionItem', () => {
   let wrapper
@@ -101,6 +102,67 @@ describe('CollectionItem', () => {
 
     test('should not render the headingUrl', () => {
       expect(wrapper.find('a')).toHaveLength(0)
+    })
+
+    describe('when five or more metadata items are passed', () => {
+      beforeAll(() => {
+        wrapper = mount(
+          <CollectionItem
+            headingUrl={interactionItem.headingUrl}
+            headingText={interactionItem.headingText}
+            badges={interactionItem.badges}
+            metadata={interactionItem.metadata}
+          />
+        )
+      })
+
+      test('should render the component', () => {
+        expect(wrapper.find(CollectionItem).exists()).toBe(true)
+      })
+
+      test('the items should be hidden behind a details dropdown', () => {
+        expect(wrapper.find('details').exists()).toBe(true)
+      })
+
+      test('the details summary should display the default text', () => {
+        expect(
+          wrapper
+            .find('summary span')
+            .first()
+            .text()
+        ).toBe('View details')
+      })
+    })
+
+    describe('when five or more metadata items are passed and a type is passed', () => {
+      beforeAll(() => {
+        wrapper = mount(
+          <CollectionItem
+            headingUrl={interactionItem.headingUrl}
+            headingText={interactionItem.headingText}
+            badges={interactionItem.badges}
+            metadata={interactionItem.metadata}
+            type="interaction"
+          />
+        )
+      })
+
+      test('should render the component', () => {
+        expect(wrapper.find(CollectionItem).exists()).toBe(true)
+      })
+
+      test('the items should be hidden behind a details dropdown', () => {
+        expect(wrapper.find('details').exists()).toBe(true)
+      })
+
+      test('the details summary should display the type', () => {
+        expect(
+          wrapper
+            .find('summary span')
+            .first()
+            .text()
+        ).toBe('View interaction details')
+      })
     })
   })
 })


### PR DESCRIPTION
Hide `collectionItem` metadata behind details if > 4. Add optional prop `type` to pass to the details summary message. If no `type` prop is passed the message will display 'View details'.

# Less than 5 items

![before](https://user-images.githubusercontent.com/42253716/72344215-976bb980-36c8-11ea-906b-c805d18743d5.png)

# More than 5 items

![after2](https://user-images.githubusercontent.com/42253716/72344240-a0f52180-36c8-11ea-89b9-eef7c50f0834.png)

# More than 5 items (expanded)

![after1](https://user-images.githubusercontent.com/42253716/72344246-aa7e8980-36c8-11ea-8ea6-ba249434a01a.png)