### PR TITLE
feat: allow CollectionItem to pass border-colour to the badge component

### DIFF
--- a/src/collection-list/CollectionItem.jsx
+++ b/src/collection-list/CollectionItem.jsx
@@ -66,7 +66,9 @@ function CollectionItem({
       {badges && (
         <StyledBadgesWrapper>
           {badges.map((badge) => (
-            <Badge key={badge}>{badge}</Badge>
+            <Badge key={badge.text} borderColour={badge.borderColour}>
+              {badge.text}
+            </Badge>
           ))}
         </StyledBadgesWrapper>
       )}
@@ -98,7 +100,12 @@ CollectionItem.propTypes = {
   headingUrl: PropTypes.string,
   headingText: PropTypes.string.isRequired,
   subheading: PropTypes.string,
-  badges: PropTypes.arrayOf(PropTypes.string),
+  badges: PropTypes.arrayOf(
+    PropTypes.shape({
+      text: PropTypes.string,
+      borderColour: PropTypes.string,
+    })
+  ),
   metadata: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/src/collection-list/__fixtures__/capitalProfileItem.json
+++ b/src/collection-list/__fixtures__/capitalProfileItem.json
@@ -13,6 +13,6 @@
     }
   ],
   "badges": [
-    "United States"
+    {"text": "United States"}
   ]
 }

--- a/src/collection-list/__fixtures__/capitalProfiles.json
+++ b/src/collection-list/__fixtures__/capitalProfiles.json
@@ -14,8 +14,12 @@
       }
     ],
     "badges": [
-      "United Kingdom",
-      "Global HQ"
+      {
+        "text": "United Kingdom"
+      },
+      {
+        "text": "Global HQ"
+      }
     ]
   },
   {
@@ -33,7 +37,9 @@
       }
     ],
     "badges": [
-      "United States"
+      {
+        "text": "United States"
+      }
     ]
   },
   {
@@ -51,7 +57,9 @@
       }
     ],
     "badges": [
-      "United States"
+      {
+        "text": "United States"
+      }
     ]
   },
   {
@@ -69,7 +77,9 @@
       }
     ],
     "badges": [
-      "United Kingdom"
+      {
+        "text": "United Kingdom"
+      }
     ]
   },
   {
@@ -87,8 +97,12 @@
       }
     ],
     "badges": [
-      "United Kingdom",
-      "Global HQ"
+      {
+        "text": "United Kingdom"
+      },
+      {
+        "text": "Global HQ"
+      }
     ]
   },
   {
@@ -106,7 +120,9 @@
       }
     ],
     "badges": [
-      "United Kingdom"
+      {
+        "text": "United Kingdom"
+      }
     ]
   },
   {
@@ -124,7 +140,9 @@
       }
     ],
     "badges": [
-      "United Kingdom"
+      {
+        "text": "United Kingdom"
+      }
     ]
   },
   {
@@ -142,7 +160,9 @@
       }
     ],
     "badges": [
-      "United Kingdom"
+      {
+        "text": "United Kingdom"
+      }
     ]
   },
   {
@@ -160,7 +180,9 @@
       }
     ],
     "badges": [
-      "United Kingdom"
+      {
+        "text": "United Kingdom"
+      }
     ]
   },
   {
@@ -178,7 +200,9 @@
       }
     ],
     "badges": [
-      "United Kingdom"
+      {
+        "text": "United Kingdom"
+      }
     ]
   },
   {
@@ -196,7 +220,9 @@
       }
     ],
     "badges": [
-      "United Kingdom"
+      {
+        "text": "United Kingdom"
+      }
     ]
   },
   {
@@ -214,7 +240,9 @@
       }
     ],
     "badges": [
-      "United Kingdom"
+      {
+        "text": "United Kingdom"
+      }
     ]
   }
 ]

--- a/src/collection-list/__fixtures__/interactionItem.json
+++ b/src/collection-list/__fixtures__/interactionItem.json
@@ -24,6 +24,9 @@
     }
   ],
   "badges": [
-    "Interaction"
+    {
+      "text": "Interaction",
+      "borderColour": "rgb(0, 100, 53)"
+    }
   ]
 }

--- a/src/collection-list/__tests__/CollectionItem.test.jsx
+++ b/src/collection-list/__tests__/CollectionItem.test.jsx
@@ -165,4 +165,23 @@ describe('CollectionItem', () => {
       })
     })
   })
+
+  describe('when a colour is specified in the badge object', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <CollectionItem
+          headingText={interactionItem.headingText}
+          badges={interactionItem.badges}
+        />
+      )
+    })
+
+    test('should render the component', () => {
+      expect(wrapper.find(CollectionItem).exists()).toBe(true)
+    })
+
+    test('should pass the borderColour to the Badge component', () => {
+      expect(wrapper.find(Badge).prop('borderColour')).toBe('rgb(0, 100, 53)')
+    })
+  })
 })


### PR DESCRIPTION
Refactor the CollectionItem component to allow it to pass a `border-colour` to the badge component.

## No colour passed (defaults to `GREY_2`)

![noColour](https://user-images.githubusercontent.com/42253716/72360012-3ef7e480-36e7-11ea-8dc7-45c94169480c.png)

## Green passed 

![colour](https://user-images.githubusercontent.com/42253716/72360106-62229400-36e7-11ea-84a7-e4c37bb19056.png)