### PR TITLE
feat: Make the premature form exit prompt configurable

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "storybook:release": "yarn storybook:build && cp -R ./.circleci ./storybook-static/.circleci && git-directory-deploy --directory storybook-static --branch gh-pages",
     "prepack": "yarn build",
     "release": "semantic-release --debug",
-    "postpublish": "[ \"${npm_config_tag:-latest}\" != latest ] || yarn storybook:release"
+    "postpublish2": "[ \"${npm_config_tag:-latest}\" != latest ] || yarn storybook:release"
   },
   "husky": {
     "hooks": {
@@ -145,7 +145,7 @@
       "enzyme-to-json/serializer"
     ],
     "testPathIgnorePatterns": [
-      "<rootDir>/.history/", 
+      "<rootDir>/.history/",
       "<rootDir>/node_modules/"
     ]
   },

--- a/src/forms/elements/Form.jsx
+++ b/src/forms/elements/Form.jsx
@@ -4,13 +4,21 @@ import LoadingBox from '@govuk-react/loading-box'
 
 import useFormContext from '../hooks/useFormContext'
 
-function Form({ initialValues, initialStep, onSubmit, scrollToTop, children }) {
+function Form({
+  initialValues,
+  initialStep,
+  onSubmit,
+  scrollToTop,
+  onExit,
+  children,
+}) {
   return (
     <useFormContext.Provider
       initialValues={initialValues}
       initialStep={initialStep}
       onSubmit={onSubmit}
       scrollToTop={scrollToTop}
+      onExit={onExit}
     >
       <FormWrapper>{children}</FormWrapper>
     </useFormContext.Provider>
@@ -22,6 +30,7 @@ Form.propTypes = {
   initialStep: PropTypes.number,
   onSubmit: PropTypes.func,
   scrollToTop: PropTypes.bool,
+  onExit: PropTypes.func,
   children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]),
 }
 
@@ -30,6 +39,7 @@ Form.defaultProps = {
   initialStep: 0,
   onSubmit: null,
   scrollToTop: true,
+  onExit: null,
   children: null,
 }
 

--- a/src/forms/hooks/__tests__/useForm.test.jsx
+++ b/src/forms/hooks/__tests__/useForm.test.jsx
@@ -14,6 +14,13 @@ const testField2 = {
   label: 'testLabel2',
 }
 
+const triggerOnBeforeUnload = () => {
+  const event = document.createEvent('HTMLEvents')
+  event.initEvent('beforeunload', true)
+  event.eventName = 'beforeunload'
+  document.dispatchEvent(event)
+}
+
 describe('useForm', () => {
   let formState
 
@@ -278,6 +285,40 @@ describe('useForm', () => {
     test('should scroll to the top of the page', () => {
       expect(window.scrollTo).toHaveBeenCalledTimes(1)
       expect(window.scrollTo).toHaveBeenCalledWith(0, 0)
+    })
+  })
+
+  describe('when form is left prematurely and onExit is specified', () => {
+    const onExitSpy = jest.fn().mockReturnValue('Exit prompt message')
+
+    beforeAll(async () => {
+      const hook = renderHook(() => useForm({ onExit: onExitSpy }))
+
+      await act(async () => {
+        await hook.result.current.setFieldTouched('testField', true)
+        triggerOnBeforeUnload()
+      })
+    })
+
+    test('should show a confirmation prompt', () => {
+      expect(onExitSpy).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('when form is left prematurely and onExit is not specified', () => {
+    const onExitSpy = jest.fn()
+
+    beforeAll(async () => {
+      const hook = renderHook(() => useForm())
+
+      await act(async () => {
+        await hook.result.current.setFieldTouched('testField', true)
+        triggerOnBeforeUnload()
+      })
+    })
+
+    test('should not show a confirmation prompt', () => {
+      expect(onExitSpy).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
Sometimes we might not need the prompt when user exists a form without submitting.