### PR TITLE
fix: Trigger an error if a company name has more than 30 chars within FieldDnbCompany

### DIFF
--- a/src/forms/elements/FieldCheckboxes.jsx
+++ b/src/forms/elements/FieldCheckboxes.jsx
@@ -69,7 +69,10 @@ const FieldCheckboxes = ({
 
 FieldCheckboxes.propTypes = {
   name: PropTypes.string.isRequired,
-  validate: PropTypes.func,
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
   required: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -22,10 +22,23 @@ import useDnbSearch from '../../entity-search/useDnbSearch'
 import FormActions from './FormActions'
 import EntityList from '../../entity-search/EntityList'
 
+const COMPANY_NAME_MIN_LENGTH = 2
+const COMPANY_NAME_MAX_LENGTH = 30
+
 const StyledUnorderedList = styled(UnorderedList)`
   list-style-type: disc;
   padding-left: ${SPACING.SCALE_5};
 `
+
+const validateMinLength = (minLength) => (value) =>
+  value && value.length < minLength
+    ? `Enter company name that is ${minLength} characters long or more`
+    : null
+
+const validateMaxLength = (maxLength) => (value) =>
+  value && value.length > maxLength
+    ? `Enter company name that is no longer than ${maxLength} characters`
+    : null
 
 const FieldDnbCompany = ({
   name,
@@ -81,12 +94,10 @@ const FieldDnbCompany = ({
         name="dnbCompanyName"
         type="search"
         required="Enter company name"
-        validate={(value) =>
-          value && value.length < 2
-            ? 'Enter company name that is 2 characters long or more'
-            : null
-        }
-        maxLength={30}
+        validate={[
+          validateMinLength(COMPANY_NAME_MIN_LENGTH),
+          validateMaxLength(COMPANY_NAME_MAX_LENGTH),
+        ]}
       />
 
       <FieldInput

--- a/src/forms/elements/FieldInput.jsx
+++ b/src/forms/elements/FieldInput.jsx
@@ -62,7 +62,10 @@ const FieldInput = ({
 FieldInput.propTypes = {
   name: PropTypes.string.isRequired,
   type: PropTypes.string.isRequired,
-  validate: PropTypes.func,
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
   required: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/src/forms/elements/FieldRadios.jsx
+++ b/src/forms/elements/FieldRadios.jsx
@@ -55,7 +55,10 @@ const FieldRadios = ({
 
 FieldRadios.propTypes = {
   name: PropTypes.string.isRequired,
-  validate: PropTypes.func,
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
   required: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),

--- a/src/forms/elements/FieldSelect.jsx
+++ b/src/forms/elements/FieldSelect.jsx
@@ -55,7 +55,10 @@ FieldSelect.propTypes = {
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   hint: PropTypes.string,
-  validate: PropTypes.func,
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
   required: PropTypes.string,
   options: PropTypes.arrayOf(
     PropTypes.shape({

--- a/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
+++ b/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
@@ -103,15 +103,6 @@ describe('FieldDnbCompany', () => {
       ).toEqual('Company name')
     })
 
-    test('should limit the number of characters in the company name filter to 30', () => {
-      expect(
-        wrapper
-          .find(FieldInput)
-          .at(0)
-          .prop('maxLength')
-      ).toEqual(30)
-    })
-
     test('should render the company postcode filter', () => {
       expect(
         wrapper
@@ -197,6 +188,31 @@ describe('FieldDnbCompany', () => {
     test('should show an error', () => {
       expect(wrapper.text()).toContain(
         'Enter company name that is 2 characters long or more'
+      )
+    })
+  })
+
+  describe('when the search button is clicked with company name longer than the maximum of 30 characters', () => {
+    beforeAll(async () => {
+      wrapper = wrapFieldDnbCompanyForm()
+
+      wrapper.find('input[name="dnbCompanyName"]').simulate('change', {
+        target: { value: '0-------10--------20--------30+++' },
+      })
+
+      wrapper
+        .find(FormActions)
+        .find('button')
+        .simulate('click')
+
+      await act(flushPromises)
+
+      wrapper.update()
+    })
+
+    test('should show an error', () => {
+      expect(wrapper.text()).toContain(
+        'Enter company name that is no longer than 30 characters'
       )
     })
   })


### PR DESCRIPTION
Fixes an issue when a company name was truncated when pasted, users then didn't get any results when searching.