### PR TITLE
ci: Enable Docker Layer Caching on CircleCI to speed-up tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,8 @@ version: 2 # Do not upgrade to 2.1 until CircleCI CLI supports it
 
 jobs:
   build:
+    machine:
+      docker_layer_caching: true
     docker:
       - image: circleci/node:10.16.0
     steps:


### PR DESCRIPTION
Enable [caching of Docker layers](https://circleci.com/docs/2.0/docker-layer-caching/) which will speed-up our tests.