### PR TITLE
feat: Add error state to Typeahead

### DIFF
--- a/src/typeahead/Typeahead.jsx
+++ b/src/typeahead/Typeahead.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import Select, { components as comps } from 'react-select'
 import AsyncSelect from 'react-select/async'
-import defaultStyles from './styles'
+import defaultStyles, { errorStyles } from './styles'
 import Highlighter from './Highlighter'
 
 const Option = ({ selectProps: { inputValue }, data: { label }, ...props }) => (
@@ -15,10 +15,10 @@ Option.propTypes = comps.Option.propTypes
 export const filterOption = ({ label = '' }, query) =>
   label.toLowerCase().includes(query)
 
-const Typeahead = ({ options, styles, components, ...props }) => {
+const Typeahead = ({ options, styles, components, error, ...props }) => {
   const customisedProps = {
     styles: {
-      ...defaultStyles,
+      ...(error ? errorStyles : defaultStyles),
       ...styles,
     },
     components: { Option },

--- a/src/typeahead/__stories__/Typeahead.stories.jsx
+++ b/src/typeahead/__stories__/Typeahead.stories.jsx
@@ -40,6 +40,16 @@ storiesOf('Typeahead/Single select', module)
       placeholder="Search..."
     />
   ))
+  .add('Error', () => (
+    <Typeahead
+      error={true}
+      isMulti={false}
+      closeMenuOnSelect={false}
+      name="test_1"
+      options={options}
+      placeholder="Search..."
+    />
+  ))
   .add('Options - pre-selected option', () => (
     <Typeahead
       isMulti={false}

--- a/src/typeahead/__tests__/Typeahead.test.jsx
+++ b/src/typeahead/__tests__/Typeahead.test.jsx
@@ -31,6 +31,10 @@ describe('Typeahead', () => {
     expect(filterOption({ label: 'foooo' }, 'bar')).toBeFalsy()
     expect(filterOption({}, 'foo')).toBeFalsy()
   })
+  test('Error coverage', () => {
+    // This is just to make the coverage report happy
+    Typeahead({ ...BASIC_PROPS, error: true })
+  })
   test('Highlighter', () => {
     // Make code coverage happy
     Highlighter({ searchStr: 'foo' })

--- a/src/typeahead/styles.js
+++ b/src/typeahead/styles.js
@@ -7,6 +7,7 @@ import {
   GREY_2,
   GREY_3,
   GREY_4,
+  ERROR_COLOUR,
 } from 'govuk-colours'
 import {
   SPACING,
@@ -75,6 +76,14 @@ const defaultStyles = {
       backgroundColor: GREY_2,
       cursor: 'pointer',
     },
+  }),
+}
+
+export const errorStyles = {
+  ...defaultStyles,
+  control: (...args) => ({
+    ...defaultStyles.control(...args),
+    border: `4px solid ${ERROR_COLOUR}`,
   }),
 }
 


### PR DESCRIPTION
Ads the `error` prop to `Typeahead`, which toggles the red border so its error state is consistent with the rest of `govuk-react` components.