### PR TITLE
refactor: Add options to currency formatter

### DIFF
--- a/src/utils/NumberUtils.js
+++ b/src/utils/NumberUtils.js
@@ -11,7 +11,7 @@ export default class NumberUtils {
     return formatter.format(number)
   }
 
-  static currencyGBP(number) {
+  static currencyGBP(number, options = { maximumSignificantDigits: 21 }) {
     if (!number && number !== 0) {
       return null
     }
@@ -19,13 +19,13 @@ export default class NumberUtils {
     const formatter = new Intl.NumberFormat('en-GB', {
       style: 'currency',
       currency: 'GBP',
-      maximumSignificantDigits: 21,
+      ...options,
     })
 
     return formatter.format(number)
   }
 
-  static currencyUSD(number) {
+  static currencyUSD(number, options = { maximumSignificantDigits: 21 }) {
     if (!number && number !== 0) {
       return null
     }
@@ -33,7 +33,7 @@ export default class NumberUtils {
     const formatter = new Intl.NumberFormat('en-US', {
       style: 'currency',
       currency: 'USD',
-      maximumSignificantDigits: 21,
+      ...options,
     })
 
     return formatter.format(number)

--- a/src/utils/__tests__/NumberUtils.test.js
+++ b/src/utils/__tests__/NumberUtils.test.js
@@ -42,4 +42,22 @@ describe('NumberUtils.js', () => {
       expect(NumberUtils.currencyUSD(1000000)).toEqual('$1,000,000')
     })
   })
+
+  describe('passing an options object to currencyGBP()', () => {
+    test('should format to 2 significant digits', () => {
+      const expected = NumberUtils.currencyGBP(1234567.89, {
+        maximumSignificantDigits: 2,
+      })
+      expect('£1,200,000').toEqual(expected)
+    })
+  })
+
+  describe('passing an options object to currencyUSD()', () => {
+    test('should format to 2 significant digits', () => {
+      const expected = NumberUtils.currencyUSD(1234567.89, {
+        maximumSignificantDigits: 2,
+      })
+      expect('$1,200,000').toEqual(expected)
+    })
+  })
 })


### PR DESCRIPTION
Pass an options object to our currency functions allowing consumers to format currency based on their requirements.

A list of options can be found here:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/NumberFormat