### PR TITLE
Fix upper case bug in typeahead component

### DIFF
--- a/src/typeahead/Typeahead.jsx
+++ b/src/typeahead/Typeahead.jsx
@@ -13,7 +13,7 @@ const Option = ({ selectProps: { inputValue }, data: { label }, ...props }) => (
 Option.propTypes = comps.Option.propTypes
 
 export const filterOption = ({ label = '' }, query) =>
-  label.toLowerCase().includes(query)
+  label.toLowerCase().includes(query.toLowerCase())
 
 const Typeahead = ({ options, styles, components, error, ...props }) => {
   const customisedProps = {


### PR DESCRIPTION
This change fixes a bug in the typeahead component which means if you search in upper case it doesn't return any results. 

This fix makes the query string against the filterOptions lower case. 

You can test this by searching with capital letters in any of the typeahead examples. 