### PR TITLE
fix: fix totalPages bug and allow overriding of itemsPerPage

### DIFF
--- a/src/collection-list/CollectionDownload.jsx
+++ b/src/collection-list/CollectionDownload.jsx
@@ -5,7 +5,7 @@ import pluralize from 'pluralize'
 import { MEDIA_QUERIES } from '@govuk-react/constants'
 import Button from '@govuk-react/button'
 import CollectionHeaderRow from './CollectionHeaderRow'
-import { MAX_ITEMS_TO_DOWNLOAD } from './constants'
+import MAX_ITEMS_TO_DOWNLOAD from './constants'
 
 const StyledInnerText = styled('div')`
   width: 100%;

--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -1,7 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
 
-import { DEFAULT_ITEMS_PER_PAGE } from './constants'
 import Pagination from '../pagination/Pagination'
 import CollectionHeader from './CollectionHeader'
 import CollectionDownload from './CollectionDownload'
@@ -16,8 +15,9 @@ function CollectionList({
   onPageClick,
   getPageUrl,
   activePage,
+  itemsPerPage,
 }) {
-  const totalPages = Math.floor(totalItems / DEFAULT_ITEMS_PER_PAGE) + 1
+  const totalPages = Math.ceil(totalItems / itemsPerPage)
 
   return (
     <>
@@ -66,6 +66,7 @@ CollectionList.propTypes = {
   onPageClick: PropTypes.func,
   getPageUrl: PropTypes.func,
   activePage: PropTypes.number,
+  itemsPerPage: PropTypes.number,
 }
 
 CollectionList.defaultProps = {
@@ -75,6 +76,7 @@ CollectionList.defaultProps = {
   onPageClick: null,
   getPageUrl: (page) => `#page-${page}`,
   activePage: 1,
+  itemsPerPage: 10,
 }
 
 export default CollectionList

--- a/src/collection-list/__stories__/CollectionList.stories.jsx
+++ b/src/collection-list/__stories__/CollectionList.stories.jsx
@@ -2,7 +2,6 @@ import React, { useState } from 'react'
 import { storiesOf } from '@storybook/react'
 import CollectionList from '../CollectionList'
 
-import { DEFAULT_ITEMS_PER_PAGE } from '../constants'
 import profilesFixture from '../__fixtures__/capitalProfiles'
 
 const collectionStories = storiesOf('Collection', module)
@@ -11,8 +10,8 @@ const CollectionWithState = () => {
   const [activePage, setActivePage] = useState(1)
 
   const index = activePage - 1
-  const offset = index * DEFAULT_ITEMS_PER_PAGE
-  const limit = (index + 1) * DEFAULT_ITEMS_PER_PAGE
+  const offset = index * 10
+  const limit = (index + 1) * 10
 
   const items = profilesFixture.slice(offset, limit)
 

--- a/src/collection-list/__tests__/CollectionList.test.jsx
+++ b/src/collection-list/__tests__/CollectionList.test.jsx
@@ -24,6 +24,7 @@ describe('CollectionItem', () => {
           getPageUrl={getPageUrl}
           onPageClick={onPageClick}
           activePage={2}
+          itemsPerPage={10}
         />
       )
     })

--- a/src/collection-list/constants.js
+++ b/src/collection-list/constants.js
@@ -1,2 +1,3 @@
-export const MAX_ITEMS_TO_DOWNLOAD = 5000
-export const DEFAULT_ITEMS_PER_PAGE = 10
+const MAX_ITEMS_TO_DOWNLOAD = 5000
+
+export default MAX_ITEMS_TO_DOWNLOAD


### PR DESCRIPTION
Previously, when you had a round ten items on a page you would get a blank additional page. For example, 30 items would result in a blank 4th page. This PR fixes that. 

Also, you can now override the default number of items per page from outside the component by passing the `itemsPerPage` prop. It defaults to `10` if nothing is passed. 