### PR TITLE
ci: Deploy to GH pages only on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ jobs:
   build:
     docker:
       - image: circleci/node:10.16.0
+        environment:
+          CI: true
     steps:
       - checkout
       - restore_cache:

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   },
   "scripts": {
     "start": "yarn storybook",
-    "build": "rimraf dist && NODE_ENV=production babel src --out-dir dist --ignore **/*.stories.jsx,**/*.test.jsx,**/*.test.js,**/__snapshots__,**/__tests__,**/__mocks__,**/__fixtures__",
+    "build": "rimraf dist && NODE_ENV=production babel src --out-dir dist --ignore '**/*.stories.jsx,**/*.test.jsx,**/*.test.js,**/__snapshots__,**/__tests__,**/__mocks__,**/__fixtures__'",
     "test": "jest",
     "test:update": "jest --updateSnapshot",
     "lint": "eslint './src/**/*.{js,jsx}'",
@@ -26,7 +26,7 @@
     "storybook:release": "yarn storybook:build && cp -R ./.circleci ./storybook-static/.circleci && git-directory-deploy --directory storybook-static --branch gh-pages",
     "prepack": "yarn build",
     "release": "semantic-release --debug",
-    "postpublish": "[ \"${npm_config_tag:-latest}\" != latest ] || yarn storybook:release"
+    "postpublish": "\"$CI\" == true && yarn storybook:release"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This change will allow to use `yalc publish`.