### PR TITLE
fix: use index for CollectionItem key

### DIFF
--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -1,3 +1,6 @@
+/* eslint-disable react/no-array-index-key */
+// this is because there isn't necessarily a unique id to use as the key
+
 import React from 'react'
 import PropTypes from 'prop-types'
 
@@ -34,9 +37,12 @@ function CollectionList({
       />
 
       {items.map(
-        ({ headingText, headingUrl, subheading, badges, metadata, type }) => (
+        (
+          { headingText, headingUrl, subheading, badges, metadata, type },
+          index
+        ) => (
           <CollectionItem
-            key={headingText + headingUrl}
+            key={index}
             headingUrl={headingUrl}
             headingText={headingText}
             subheading={subheading}

--- a/src/collection-list/__tests__/CollectionList.test.jsx
+++ b/src/collection-list/__tests__/CollectionList.test.jsx
@@ -33,6 +33,12 @@ describe('CollectionItem', () => {
       expect(wrapper.find(CollectionItem)).toHaveLength(12)
     })
 
+    test('each item should have a key corresponding to its index', () => {
+      wrapper.find(CollectionItem).forEach((item, index) => {
+        expect(item.key()).toEqual(String(index))
+      })
+    })
+
     test('should render the header', () => {
       const header = wrapper.find(CollectionHeader)
       expect(header.exists()).toBe(true)


### PR DESCRIPTION
Use the index for the CollectionItem key as the current use of heading and url result in clashing keys in the country specific exportHistory implementation of this component in the frontend.

There isn't a unique id provided for these components, so the next best option is to use the index. This isn't normally advised and hence the `/* eslint-disable react/no-array-index-key */`

This is detailed in the docs here - https://reactjs.org/docs/lists-and-keys.html#keys

I've also added a test for this. 