### PR TITLE
fix: Ensure key is unique across pages

### DIFF
--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -42,7 +42,7 @@ function CollectionList({
           index
         ) => (
           <CollectionItem
-            key={index}
+            key={[totalItems, activePage, index].join('-')}
             headingUrl={headingUrl}
             headingText={headingText}
             subheading={subheading}

--- a/src/collection-list/__tests__/CollectionList.test.jsx
+++ b/src/collection-list/__tests__/CollectionList.test.jsx
@@ -13,6 +13,7 @@ describe('CollectionItem', () => {
   const onPageClick = () => {}
 
   describe('when all props are passed', () => {
+    const activePage = 2
     beforeAll(() => {
       wrapper = mount(
         <CollectionList
@@ -23,7 +24,7 @@ describe('CollectionItem', () => {
           downloadUrl="http://example.com"
           getPageUrl={getPageUrl}
           onPageClick={onPageClick}
-          activePage={2}
+          activePage={activePage}
           itemsPerPage={10}
         />
       )
@@ -33,9 +34,11 @@ describe('CollectionItem', () => {
       expect(wrapper.find(CollectionItem)).toHaveLength(12)
     })
 
-    test('each item should have a key corresponding to its index', () => {
+    test('each item should have a unique key created', () => {
       wrapper.find(CollectionItem).forEach((item, index) => {
-        expect(item.key()).toEqual(String(index))
+        expect(item.key()).toEqual(
+          [profilesFixture.length, activePage, index].join('-')
+        )
       })
     })
 


### PR DESCRIPTION
Using the array index for a key may lead to incorrect data being displayed as this might not be unique enough. This PR uses the total items and the active page (along with the index) to generate a key