### PR TITLE
fix: render no pagination when there are 0 results

### DIFF
--- a/src/collection-list/CollectionList.jsx
+++ b/src/collection-list/CollectionList.jsx
@@ -64,8 +64,8 @@ function CollectionList({
 }
 
 CollectionList.propTypes = {
-  totalItems: PropTypes.number.isRequired,
-  itemName: PropTypes.string.isRequired,
+  totalItems: PropTypes.number,
+  itemName: PropTypes.string,
   addItemUrl: PropTypes.string,
   downloadUrl: PropTypes.string,
   items: PropTypes.array,
@@ -76,9 +76,11 @@ CollectionList.propTypes = {
 }
 
 CollectionList.defaultProps = {
+  totalItems: 0,
+  itemName: 'result',
   addItemUrl: null,
   downloadUrl: null,
-  items: null,
+  items: [],
   onPageClick: null,
   getPageUrl: (page) => `#page-${page}`,
   activePage: 1,

--- a/src/collection-list/__stories__/CollectionList.stories.jsx
+++ b/src/collection-list/__stories__/CollectionList.stories.jsx
@@ -32,3 +32,7 @@ const CollectionWithState = () => {
 }
 
 collectionStories.add('Collection List', () => <CollectionWithState />)
+
+collectionStories.add('Collection List with 0 items', () => (
+  <CollectionList totalItems={0} itemName="results" />
+))

--- a/src/collection-list/__tests__/CollectionList.test.jsx
+++ b/src/collection-list/__tests__/CollectionList.test.jsx
@@ -7,7 +7,7 @@ import CollectionHeader from '../CollectionHeader'
 import CollectionItem from '../CollectionItem'
 import CollectionDownload from '../CollectionDownload'
 
-describe('CollectionItem', () => {
+describe('CollectionList', () => {
   let wrapper
   const getPageUrl = (page) => `#page-${page}`
   const onPageClick = () => {}
@@ -87,6 +87,16 @@ describe('CollectionItem', () => {
 
     test('should use the default "getPageUrl" prop', () => {
       expect(wrapper.find(Pagination).prop('getPageUrl')).not.toBeNull()
+    })
+  })
+
+  describe('when no items are passed', () => {
+    beforeAll(() => {
+      wrapper = mount(<CollectionList />)
+    })
+
+    test('should not render pagination', () => {
+      expect(wrapper.find(Pagination).isEmptyRender()).toBe(true)
     })
   })
 })

--- a/src/pagination/Pagination.jsx
+++ b/src/pagination/Pagination.jsx
@@ -74,7 +74,7 @@ const StyledPagesTruncation = styled('span')`
 function Pagination({ totalPages, activePage, onPageClick, getPageUrl }) {
   const visiblePieces = computeVisiblePieces(totalPages, activePage)
 
-  if (totalPages === 1) {
+  if (totalPages < 2) {
     return null
   }
 


### PR DESCRIPTION
My previous bug fix introduced this small bug. Before when you had 0 results the pagination would render. Now when the `totalPages` === 0 the pagination component won't render. 