### PR TITLE
Change the way StatusMessage returns

### DIFF
--- a/src/status-message/StatusMessage.jsx
+++ b/src/status-message/StatusMessage.jsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import PropTypes from 'prop-types'
 import styled from 'styled-components'
 import { spacing } from '@govuk-react/lib'

--- a/src/status-message/StatusMessage.jsx
+++ b/src/status-message/StatusMessage.jsx
@@ -5,7 +5,7 @@ import { spacing } from '@govuk-react/lib'
 import { BLUE } from 'govuk-colours'
 import { FOCUSABLE, SPACING } from '@govuk-react/constants'
 
-const StyledStatusMessage = styled('div')`
+const StatusMessage = styled('div')`
   border: ${({ colour }) => `${SPACING.SCALE_1} solid ${colour}`};
   color: ${({ colour }) => colour};
   font-weight: bold;
@@ -14,10 +14,6 @@ const StyledStatusMessage = styled('div')`
   ${spacing.withWhiteSpace({ marginBottom: 6 })};
   ${FOCUSABLE};
 `
-
-const StatusMessage = ({ colour, children }) => {
-  return <StyledStatusMessage colour={colour}>{children}</StyledStatusMessage>
-}
 
 StatusMessage.propTypes = {
   colour: PropTypes.string,


### PR DESCRIPTION
We have been asked by the performance analysis team to add a GA identifier to the 'black box' message that appears on an unmatched company page. In order to do this I need to add a new HTML attribute to it, which is why I am changing the way that the StatusMessage returns.