### PR TITLE
feat: Allow to pass JSX elements as form hints

### DIFF
--- a/src/forms/elements/FieldAddress.jsx
+++ b/src/forms/elements/FieldAddress.jsx
@@ -148,7 +148,7 @@ FieldAddress.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   country: PropTypes.shape({
     id: PropTypes.string.isRequired,
     name: PropTypes.string.isRequired,

--- a/src/forms/elements/FieldCheckboxes.jsx
+++ b/src/forms/elements/FieldCheckboxes.jsx
@@ -76,7 +76,7 @@ FieldCheckboxes.propTypes = {
   required: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -168,7 +168,7 @@ FieldDnbCompany.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   country: PropTypes.string,
   apiEndpoint: PropTypes.string.isRequired,
   queryParams: PropTypes.shape({}),

--- a/src/forms/elements/FieldInput.jsx
+++ b/src/forms/elements/FieldInput.jsx
@@ -69,7 +69,7 @@ FieldInput.propTypes = {
   required: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
 }
 
 FieldInput.defaultProps = {

--- a/src/forms/elements/FieldRadios.jsx
+++ b/src/forms/elements/FieldRadios.jsx
@@ -62,7 +62,7 @@ FieldRadios.propTypes = {
   required: PropTypes.string,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   options: PropTypes.arrayOf(
     PropTypes.shape({
       label: PropTypes.string.isRequired,

--- a/src/forms/elements/FieldSelect.jsx
+++ b/src/forms/elements/FieldSelect.jsx
@@ -54,7 +54,7 @@ FieldSelect.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   validate: PropTypes.oneOfType([
     PropTypes.func,
     PropTypes.arrayOf(PropTypes.func),

--- a/src/forms/elements/FieldUneditable.jsx
+++ b/src/forms/elements/FieldUneditable.jsx
@@ -29,7 +29,7 @@ FieldUneditable.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   onChangeClick: PropTypes.func,
   children: PropTypes.node.isRequired,
 }

--- a/src/forms/elements/FieldWrapper.jsx
+++ b/src/forms/elements/FieldWrapper.jsx
@@ -124,7 +124,7 @@ FieldWrapper.propTypes = {
   name: PropTypes.string.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
-  hint: PropTypes.string,
+  hint: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   error: PropTypes.string,
   showBorder: PropTypes.bool,
   children: PropTypes.node,

--- a/src/forms/elements/__tests__/FieldWrapper.test.jsx
+++ b/src/forms/elements/__tests__/FieldWrapper.test.jsx
@@ -160,6 +160,21 @@ describe('FieldWrapper', () => {
     })
   })
 
+  describe('When the hint prop contains JSX', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FieldWrapper name="testName" hint={<strong>Some JSX</strong>}>
+          Test hint
+        </FieldWrapper>
+      )
+    })
+
+    test('should render the hint as HTML', () => {
+      expect(wrapper.find(HintText).text()).toEqual('Some JSX')
+      expect(wrapper.find(HintText).find('strong').length).toEqual(1)
+    })
+  })
+
   describe('When the label and error props are specified', () => {
     beforeAll(() => {
       wrapper = mount(


### PR DESCRIPTION
Hints within form elements often contain links, this PR enables to add them.

(Technically, this is possible now but user will receive a warning due to prop validation).