### PR TITLE
feat: Add FieldTypeahead

### DIFF
--- a/src/forms/elements/FieldTypeahead.jsx
+++ b/src/forms/elements/FieldTypeahead.jsx
@@ -1,0 +1,88 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import styled from 'styled-components'
+import ErrorText from '@govuk-react/error-text'
+import {
+  BORDER_WIDTH_FORM_ELEMENT_ERROR,
+  SPACING,
+} from '@govuk-react/constants'
+import { ERROR_COLOUR } from 'govuk-colours'
+
+import useField from '../hooks/useField'
+import FieldWrapper from './FieldWrapper'
+import Typeahead from '../../typeahead/Typeahead'
+import useFormContext from '../hooks/useFormContext'
+
+const StyledWrapper = styled('div')`
+  ${(props) =>
+    props.error &&
+    `
+    border-left: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+    margin-right: ${SPACING.SCALE_3};
+    padding-left: ${SPACING.SCALE_2};
+  `}
+  textarea {
+    width: 100%;
+  }
+`
+
+const FieldTypeahead = ({
+  name,
+  validate,
+  required,
+  label,
+  legend,
+  hint,
+  ...rest
+}) => {
+  const { value, error, touched, onBlur } = useField({
+    name,
+    validate,
+    required,
+  })
+  const { setFieldValue } = useFormContext()
+
+  return (
+    <FieldWrapper {...{ name, label, legend, hint, error }}>
+      <StyledWrapper error={error}>
+        {touched && error && <ErrorText>{error}</ErrorText>}
+        <Typeahead
+          inputId={name}
+          aria-label={label || legend}
+          onBlur={onBlur}
+          onChange={(event) =>
+            setFieldValue(name, {
+              label: event.label,
+              value: event.value,
+            })
+          }
+          error={error}
+          defaultValue={value && { label: value.label }}
+          {...rest}
+        />
+      </StyledWrapper>
+    </FieldWrapper>
+  )
+}
+
+FieldTypeahead.propTypes = {
+  name: PropTypes.string.isRequired,
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
+  required: PropTypes.string,
+  label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  legend: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
+  hint: PropTypes.string,
+}
+
+FieldTypeahead.defaultProps = {
+  validate: null,
+  required: null,
+  label: null,
+  legend: null,
+  hint: null,
+}
+
+export default FieldTypeahead

--- a/src/forms/elements/__stories__/FieldTypeahead.stories.jsx
+++ b/src/forms/elements/__stories__/FieldTypeahead.stories.jsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { addDecorator, storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
+import { withKnobs } from '@storybook/addon-knobs'
+import Button from '@govuk-react/button'
+
+import Form from '../Form'
+import FieldTypeahead from '../FieldTypeahead'
+
+addDecorator(withKnobs)
+
+const asyncOptions = [
+  {
+    value: '379f390a-e083-4a2c-9cea-e3b9a08606a7',
+    label: 'Holly Clins - olHeart of the South West LEP',
+  },
+  {
+    value: '8dcd2bb8-dc73-4a42-8655-4ae42d4d3c5a',
+    label: 'Bernard Harris-Patelc - Welsh Government (Investment)',
+  },
+  {
+    value: 'a6f39399-5bf4-46cb-a686-826f73e9f0ca',
+    label: 'Dennis Kennedy',
+  },
+]
+
+const getOptions = () =>
+  new Promise((resolve) => setTimeout(resolve, 1000, asyncOptions))
+
+storiesOf('Forms', module).add('FieldTypeahead', () => (
+  <Form onSubmit={action('onSubmit')}>
+    {(state) => (
+      <>
+        <FieldTypeahead
+          label="Typeahead"
+          hint="Some hint"
+          name="testField"
+          required="Chose value"
+          loadOptions={getOptions}
+        />
+        <Button>Submit</Button>
+        <pre>{JSON.stringify(state, null, 2)}</pre>
+      </>
+    )}
+  </Form>
+))

--- a/src/forms/elements/__tests__/FieldTypeahead.test.jsx
+++ b/src/forms/elements/__tests__/FieldTypeahead.test.jsx
@@ -1,0 +1,148 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import HintText from '@govuk-react/hint-text'
+import Label from '@govuk-react/label'
+import ErrorText from '@govuk-react/error-text'
+import { act } from 'react-dom/test-utils'
+
+import Form from '../Form'
+import FieldTypeahead from '../FieldTypeahead'
+import FieldWrapper from '../FieldWrapper'
+import Typeahead from '../../../typeahead/Typeahead'
+import useFormContext from '../../hooks/useFormContext'
+
+describe('FieldTypeahead', () => {
+  describe('when the field is mounted', () => {
+    test('should set default attributes on the typeahead element', () => {
+      const wrapper = mount(
+        <Form initialValues={{ testField: { label: 'someValueLabel' } }}>
+          <FieldTypeahead name="testField" />
+        </Form>
+      )
+      const typeahead = wrapper.find(Typeahead)
+      expect(typeahead.prop('inputId')).toEqual('testField')
+      expect(typeahead.prop('defaultValue')).toEqual({
+        label: 'someValueLabel',
+      })
+      expect(typeahead.prop('onBlur')).toBeInstanceOf(Function)
+      expect(typeahead.prop('onChange')).toBeInstanceOf(Function)
+    })
+  })
+
+  describe('when the field does specify a label', () => {
+    test('should render the typeahead and a label', () => {
+      const wrapper = mount(
+        <Form>
+          <FieldTypeahead name="testField" label="testLabel" />
+        </Form>
+      )
+      expect(wrapper.find(Label).exists()).toBe(true)
+      expect(wrapper.find(Typeahead).prop('aria-label')).toEqual('testLabel')
+    })
+  })
+
+  describe('when the field does not specify a label', () => {
+    test('should render the field without a label', () => {
+      const wrapper = mount(
+        <Form>
+          <FieldTypeahead name="testField" />
+        </Form>
+      )
+      expect(wrapper.find(Label).exists()).toBe(false)
+      expect(wrapper.find(Typeahead).prop('aria-label')).toEqual(null)
+    })
+  })
+
+  describe('when the field does specify a legend', () => {
+    test('should render the field with a legend', () => {
+      const wrapper = mount(
+        <Form>
+          <FieldTypeahead name="testField" legend="testLegend" />
+        </Form>
+      )
+      expect(wrapper.find('legend').text()).toEqual('testLegend')
+      expect(wrapper.find(Typeahead).prop('aria-label')).toEqual('testLegend')
+    })
+  })
+
+  describe('when the field does specify a hint', () => {
+    test('should render the field with a legend', () => {
+      const wrapper = mount(
+        <Form>
+          <FieldTypeahead name="testField" hint="testHint" />
+        </Form>
+      )
+      expect(wrapper.find(HintText).text()).toEqual('testHint')
+    })
+  })
+
+  describe('when the validation fails', () => {
+    test('should render error message', () => {
+      const wrapper = mount(
+        <Form>
+          <FieldTypeahead name="testField" validate={() => 'testError'} />
+        </Form>
+      )
+      wrapper.find('form').simulate('submit')
+
+      expect(wrapper.find(ErrorText).text()).toEqual('testError')
+
+      const inputWrapper = wrapper
+        .find(FieldWrapper)
+        .find('div')
+        .at(1)
+      expect(inputWrapper).toHaveStyleRule('border-left', '4px solid #b10e1e')
+      expect(inputWrapper).toHaveStyleRule('margin-right', '15px')
+      expect(inputWrapper).toHaveStyleRule('padding-left', '10px')
+    })
+  })
+
+  describe('when the text is typed to the typeahead', () => {
+    test('should update field value', async () => {
+      const Value = () => {
+        const { values } = useFormContext()
+        return <pre>{JSON.stringify(values.testField)}</pre>
+      }
+
+      const options = [
+        { label: '1', value: 'one' },
+        { label: '2', value: 'two' },
+      ]
+      const wrapper = mount(
+        <Form>
+          <FieldTypeahead
+            name="testField"
+            options={options}
+            menuIsOpen={true}
+            classNamePrefix="react-select"
+          />
+          <Value />
+        </Form>
+      )
+
+      act(() => {
+        const selectWrapper = wrapper.find(Typeahead).find('Select')
+        selectWrapper.instance().selectOption(options[0])
+      })
+
+      expect(wrapper.find('pre').text()).toEqual('{"label":"1","value":"one"}')
+    })
+  })
+
+  describe('when extra props are passed to the component', () => {
+    test('should render typeahead with all the extra props', () => {
+      const wrapper = mount(
+        <Form>
+          <FieldTypeahead
+            name="testField"
+            placeholder="Type to search"
+            isMulti={false}
+          />
+        </Form>
+      )
+      const typeahead = wrapper.find(Typeahead)
+      expect(typeahead.prop('placeholder')).toEqual('Type to search')
+      expect(typeahead.prop('isMulti')).toEqual(false)
+    })
+  })
+})

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -64,6 +64,7 @@ export { default as FieldInput } from './forms/elements/FieldInput'
 export { default as FieldRadios } from './forms/elements/FieldRadios'
 export { default as FieldSelect } from './forms/elements/FieldSelect'
 export { default as FieldTextarea } from './forms/elements/FieldTextarea'
+export { default as FieldTypeahead } from './forms/elements/FieldTypeahead'
 export { default as FieldUneditable } from './forms/elements/FieldUneditable'
 
 // Metadata


### PR DESCRIPTION
Add field wrapper for `Typeahead` component so it can be used in forms.

![image](https://user-images.githubusercontent.com/4199239/76331649-50283080-62e7-11ea-8156-2a391d8a6d42.png)
