### PR TITLE
feat: refactor activityFeed to handle multiple buttons

### DIFF
--- a/src/activity-feed/ActivityFeed.jsx
+++ b/src/activity-feed/ActivityFeed.jsx
@@ -32,8 +32,7 @@ export default class ActivityFeed extends React.Component {
     activityTypeFilters: PropTypes.object,
     hasMore: PropTypes.bool,
     isLoading: PropTypes.bool,
-    contentText: PropTypes.string,
-    contentLink: PropTypes.string,
+    actions: PropTypes.node,
     totalActivities: PropTypes.number,
     isGlobalUltimate: PropTypes.bool,
     dnbHierarchyCount: PropTypes.number,
@@ -49,8 +48,7 @@ export default class ActivityFeed extends React.Component {
     activityTypeFilters: {},
     hasMore: false,
     isLoading: false,
-    contentText: null,
-    contentLink: null,
+    actions: null,
     totalActivities: 0,
     isGlobalUltimate: false,
     dnbHierarchyCount: null,
@@ -129,8 +127,7 @@ export default class ActivityFeed extends React.Component {
       onLoadMore,
       hasMore,
       isLoading,
-      contentText,
-      contentLink,
+      actions,
       children,
       totalActivities,
       isGlobalUltimate,
@@ -152,8 +149,7 @@ export default class ActivityFeed extends React.Component {
       <ActivityFeedContainer>
         <ActivityFeedHeader
           totalActivities={totalActivities}
-          contentText={contentText}
-          contentLink={contentLink}
+          actions={actions}
         />
 
         {hasFilters && (

--- a/src/activity-feed/ActivityFeedAction.jsx
+++ b/src/activity-feed/ActivityFeedAction.jsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import styled from 'styled-components'
+import PropTypes from 'prop-types'
+import Button from '@govuk-react/button'
+import { SPACING, MEDIA_QUERIES } from '@govuk-react/constants'
+
+const Link = styled('a')`
+  margin-bottom: 0;
+  margin-top: ${SPACING.SCALE_3};
+  ${MEDIA_QUERIES.TABLET} {
+    margin-left: ${SPACING.SCALE_3};
+    margin-top: 0;
+  }
+`
+
+const ActivityFeedAction = ({ text, link }) => (
+  <Button
+    key={text}
+    as={Link}
+    href={link}
+    buttonColour="#dee0e2"
+    buttonTextColour="#000"
+  >
+    {text}
+  </Button>
+)
+
+ActivityFeedAction.propTypes = {
+  text: PropTypes.string.isRequired,
+  link: PropTypes.string.isRequired,
+}
+
+export default ActivityFeedAction

--- a/src/activity-feed/ActivityFeedApp.jsx
+++ b/src/activity-feed/ActivityFeedApp.jsx
@@ -10,8 +10,7 @@ import ActivityFeed from './ActivityFeed'
  */
 export default class ActivityFeedApp extends React.Component {
   static propTypes = {
-    contentLink: PropTypes.string,
-    contentText: PropTypes.string,
+    actions: PropTypes.node,
     activityTypeFilter: PropTypes.string,
     activityTypeFilters: PropTypes.object,
     apiEndpoint: PropTypes.string.isRequired,
@@ -24,8 +23,7 @@ export default class ActivityFeedApp extends React.Component {
   static defaultProps = {
     activityTypeFilter: null,
     activityTypeFilters: {},
-    contentLink: null,
-    contentText: null,
+    actions: null,
     isGlobalUltimate: false,
     dnbHierarchyCount: null,
     isTypeFilterFlagEnabled: false,
@@ -131,8 +129,7 @@ export default class ActivityFeedApp extends React.Component {
     const { activities, isLoading, hasMore, error, total } = this.state
     const {
       activityTypeFilters,
-      contentText,
-      contentLink,
+      actions,
       isGlobalUltimate,
       dnbHierarchyCount,
       isTypeFilterFlagEnabled,
@@ -140,12 +137,12 @@ export default class ActivityFeedApp extends React.Component {
     } = this.props
 
     const isEmptyFeed = activities.length === 0 && !hasMore
+
     return (
       <ActivityFeed
         activities={activities}
         activityTypeFilters={activityTypeFilters}
-        contentText={contentText}
-        contentLink={contentLink}
+        actions={actions}
         isLoading={isLoading}
         hasMore={hasMore}
         onLoadMore={this.onLoadMore}

--- a/src/activity-feed/ActivityFeedHeader.jsx
+++ b/src/activity-feed/ActivityFeedHeader.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import Button from '@govuk-react/button'
 import { H2 } from '@govuk-react/heading'
 import styled from 'styled-components'
 import { SPACING, MEDIA_QUERIES } from '@govuk-react/constants'
@@ -36,55 +35,36 @@ const HeaderCount = styled('div')`
 
 const HeaderActions = styled('div')`
   text-align: right;
+  min-width: 60%;
 
   & > button {
     margin-bottom: 0;
   }
 `
 
-const Link = styled.a`
-  margin-bottom: 0;
-`
+const ActivityFeedHeader = ({ totalActivities, actions }) => {
+  const headerText = totalActivities
+    ? pluralize('activity', totalActivities, true)
+    : 'Activities'
 
-export default class ActivityFeedHeader extends React.Component {
-  static propTypes = {
-    totalActivities: PropTypes.number,
-    contentText: PropTypes.string,
-    contentLink: PropTypes.string,
-  }
-
-  static defaultProps = {
-    totalActivities: 0,
-    contentText: null,
-    contentLink: null,
-  }
-
-  render() {
-    const { totalActivities, contentText, contentLink } = this.props
-    const headerText = totalActivities
-      ? pluralize('activity', totalActivities, true)
-      : 'Activities'
-
-    const showAddContentButton = contentText && contentLink
-
-    return (
-      <HeaderSummary>
-        <HeaderCount>
-          <H2>{headerText}</H2>
-        </HeaderCount>
-        <HeaderActions>
-          {showAddContentButton && (
-            <Button
-              as={Link}
-              href={contentLink}
-              buttonColour="#dee0e2"
-              buttonTextColour="#000"
-            >
-              {contentText}
-            </Button>
-          )}
-        </HeaderActions>
-      </HeaderSummary>
-    )
-  }
+  return (
+    <HeaderSummary>
+      <HeaderCount>
+        <H2>{headerText}</H2>
+      </HeaderCount>
+      {actions && <HeaderActions>{actions}</HeaderActions>}
+    </HeaderSummary>
+  )
 }
+
+ActivityFeedHeader.propTypes = {
+  totalActivities: PropTypes.number,
+  actions: PropTypes.node,
+}
+
+ActivityFeedHeader.defaultProps = {
+  totalActivities: 0,
+  actions: null,
+}
+
+export default ActivityFeedHeader

--- a/src/activity-feed/__stories__/ActivityFeed.stories.jsx
+++ b/src/activity-feed/__stories__/ActivityFeed.stories.jsx
@@ -8,6 +8,7 @@ import { SPACING } from '@govuk-react/constants'
 import { ACTIVITY_TYPE_FILTERS } from '../constants'
 
 import ActivityFeed from '../ActivityFeed'
+import ActivityFeedAction from '../ActivityFeedAction'
 import activityFeedFixtures from '../__fixtures__'
 import datahubBackground from './images/data-hub-one-list-corp.png'
 import accountsAreDueFixture from '../__fixtures__/companies_house/accounts_are_due'
@@ -155,6 +156,16 @@ class ActivityFeedDemoApp extends React.Component {
     const { activities, isLoading, hasMore, error, total } = this.state
     const isEmptyFeed = activities.length === 0 && !hasMore
 
+    const ActivityFeedActions = (
+      <>
+        <ActivityFeedAction text="Refer this company" link="/referral" />
+        <ActivityFeedAction
+          text="Add interaction"
+          link="/companies/3335a773-a098-e211-a939-e4115bead28a/interactions/create"
+        />
+      </>
+    )
+
     return (
       <div>
         <ActivityFeed
@@ -165,8 +176,7 @@ class ActivityFeedDemoApp extends React.Component {
           hasMore={hasMore}
           onLoadMore={this.onLoadMore}
           isLoading={isLoading}
-          contentText="Add interaction"
-          contentLink="/companies/3335a773-a098-e211-a939-e4115bead28a/interactions/create"
+          actions={ActivityFeedActions}
           dnbHierarchyCount={8}
           isGlobalUltimate={true}
           isTypeFilterFlagEnabled={true}

--- a/src/activity-feed/__tests__/ActivityFeedAction.test.jsx
+++ b/src/activity-feed/__tests__/ActivityFeedAction.test.jsx
@@ -1,0 +1,28 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import ActivityFeedAction from '../ActivityFeedAction'
+
+describe('ActivityFeedAction', () => {
+  let wrapper
+
+  beforeAll(() => {
+    wrapper = mount(
+      <ActivityFeedAction
+        text="Test button"
+        link="http://testing.example.com"
+      />
+    )
+  })
+
+  test('should render the component', () => {
+    expect(wrapper.find(ActivityFeedAction).exists()).toBe(true)
+  })
+
+  test('should render the text', () => {
+    expect(wrapper.find(ActivityFeedAction).text()).toBe('Test button')
+  })
+
+  test('should render the button with a link', () => {
+    expect(wrapper.find("a[href='http://testing.example.com']")).toHaveLength(1)
+  })
+})

--- a/src/activity-feed/__tests__/ActivityFeedApp.test.jsx
+++ b/src/activity-feed/__tests__/ActivityFeedApp.test.jsx
@@ -5,6 +5,7 @@ import Select from '@govuk-react/select'
 import { act } from 'react-dom/test-utils'
 
 import ActivityFeedApp from '../ActivityFeedApp'
+import ActivityFeedAction from '../ActivityFeedAction'
 import SelectFilter from '../filters/SelectFilter'
 import esResults from '../__fixtures__/activity-feed-from-es'
 import { ACTIVITY_TYPE_FILTERS } from '../constants'
@@ -14,13 +15,21 @@ describe('ActivityFeedApp', () => {
   const companyId = '0f5216e0-849f-11e6-ae22-56b6b6499611'
   const basePath = 'http://localhost:3000'
   const endpoint = `/companies/${companyId}/activity-feed/data`
-  const contentLink = `/companies/${companyId}/interactions/create`
   const query = {
     from: 0,
     size: 20,
     activityTypeFilter: 'dataHubActivity',
     showDnbHierarchy: false,
   }
+  const ActivityFeedButtons = (
+    <>
+      <ActivityFeedAction text="Refer this company" link="/referral" />
+      <ActivityFeedAction
+        text="Add interaction"
+        link="/companies/3335a773-a098-e211-a939-e4115bead28a/interactions/create"
+      />
+    </>
+  )
 
   let wrapper
   let scope
@@ -36,8 +45,7 @@ describe('ActivityFeedApp', () => {
         <ActivityFeedApp
           activityTypeFilter="dataHubActivity"
           activityTypeFilters={ACTIVITY_TYPE_FILTERS}
-          contentLink={contentLink}
-          contentText="Add interaction"
+          actions={ActivityFeedButtons}
           apiEndpoint={`${basePath}${endpoint}`}
           isGlobalUltimateFlagEnabled={true}
           isTypeFilterFlagEnabled={true}
@@ -89,8 +97,7 @@ describe('ActivityFeedApp', () => {
         <ActivityFeedApp
           activityTypeFilter="dataHubActivity"
           activityTypeFilters={ACTIVITY_TYPE_FILTERS}
-          contentLink={contentLink}
-          contentText="Add interaction"
+          actions={ActivityFeedButtons}
           apiEndpoint={`${basePath}${endpoint}`}
           isGlobalUltimateFlagEnabled={true}
           isTypeFilterFlagEnabled={true}
@@ -136,8 +143,7 @@ describe('ActivityFeedApp', () => {
         <ActivityFeedApp
           activityTypeFilter="dataHubActivity"
           activityTypeFilters={ACTIVITY_TYPE_FILTERS}
-          contentLink={contentLink}
-          contentText="Add interaction"
+          actions={ActivityFeedButtons}
           apiEndpoint={`${basePath}${endpoint}`}
           isGlobalUltimateFlagEnabled={true}
           isTypeFilterFlagEnabled={true}

--- a/src/activity-feed/__tests__/ActivityFeedHeader.test.jsx
+++ b/src/activity-feed/__tests__/ActivityFeedHeader.test.jsx
@@ -2,6 +2,7 @@ import React from 'react'
 import renderer from 'react-test-renderer'
 
 import ActivityFeedHeader from '../ActivityFeedHeader'
+import ActivityFeedAction from '../ActivityFeedAction'
 
 describe('ActivityFeedHeader', () => {
   test('renders header without props', () => {
@@ -14,8 +15,12 @@ describe('ActivityFeedHeader', () => {
       .create(
         <ActivityFeedHeader
           totalActivities={999}
-          contentText="Test button"
-          contentLink="http://testing.example.com"
+          actions={
+            <ActivityFeedAction
+              text="Test button"
+              link="http://testing.example.com"
+            />
+          }
         />
       )
       .toJSON()

--- a/src/activity-feed/__tests__/__snapshots__/ActivityFeedHeader.test.jsx.snap
+++ b/src/activity-feed/__tests__/__snapshots__/ActivityFeedHeader.test.jsx.snap
@@ -1,6 +1,56 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ActivityFeedHeader renders header with all props defined 1`] = `
+.c2 {
+  color: #0b0c0c;
+  font-family: "nta",Arial,sans-serif;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+  font-weight: 700;
+  font-size: 24px;
+  line-height: 1.0416666666666667;
+  display: block;
+  margin-top: 0;
+  margin-bottom: 20px;
+}
+
+.c0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-flex-flow: row wrap;
+  -ms-flex-flow: row wrap;
+  flex-flow: row wrap;
+  border-bottom: 2px solid #000;
+  margin-bottom: 10px;
+  padding-bottom: 5px;
+}
+
+.c0 > div {
+  width: 100%;
+  margin-bottom: 5px;
+}
+
+.c1 {
+  margin-top: 5px;
+}
+
+.c1 > h2 {
+  font-weight: normal;
+  font-size: 28px;
+  margin-bottom: 0;
+}
+
+.c3 {
+  text-align: right;
+  min-width: 60%;
+}
+
+.c3 > button {
+  margin-bottom: 0;
+}
+
 .c4 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -93,89 +143,9 @@ exports[`ActivityFeedHeader renders header with all props defined 1`] = `
   max-width: 15px;
 }
 
-.c2 {
-  color: #0b0c0c;
-  font-family: "nta",Arial,sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 700;
-  font-size: 24px;
-  line-height: 1.0416666666666667;
-  display: block;
-  margin-top: 0;
-  margin-bottom: 20px;
-}
-
-.c0 {
-  display: -webkit-box;
-  display: -webkit-flex;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-flex-flow: row wrap;
-  -ms-flex-flow: row wrap;
-  flex-flow: row wrap;
-  border-bottom: 2px solid #000;
-  margin-bottom: 10px;
-  padding-bottom: 5px;
-}
-
-.c0 > div {
-  width: 100%;
-  margin-bottom: 5px;
-}
-
-.c1 {
-  margin-top: 5px;
-}
-
-.c1 > h2 {
-  font-weight: normal;
-  font-size: 28px;
-  margin-bottom: 0;
-}
-
-.c3 {
-  text-align: right;
-}
-
-.c3 > button {
-  margin-bottom: 0;
-}
-
 .c5 {
   margin-bottom: 0;
-}
-
-@media print {
-  .c4 {
-    font-size: 14px;
-    line-height: 19px;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c4 {
-    font-size: 19px;
-    line-height: 19px;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c4 {
-    width: auto;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c4 svg {
-    margin-left: 10px;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c4 {
-    margin-bottom: 32px;
-  }
+  margin-top: 15px;
 }
 
 @media print {
@@ -211,6 +181,45 @@ exports[`ActivityFeedHeader renders header with all props defined 1`] = `
     -webkit-flex-grow: 1;
     -ms-flex-positive: 1;
     flex-grow: 1;
+  }
+}
+
+@media print {
+  .c4 {
+    font-size: 14px;
+    line-height: 19px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c4 {
+    font-size: 19px;
+    line-height: 19px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c4 {
+    width: auto;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c4 svg {
+    margin-left: 10px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c4 {
+    margin-bottom: 32px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c5 {
+    margin-left: 15px;
+    margin-top: 0;
   }
 }
 
@@ -283,14 +292,6 @@ exports[`ActivityFeedHeader renders header with one activity 1`] = `
   margin-bottom: 0;
 }
 
-.c3 {
-  text-align: right;
-}
-
-.c3 > button {
-  margin-bottom: 0;
-}
-
 @media print {
   .c2 {
     color: #000;
@@ -340,9 +341,6 @@ exports[`ActivityFeedHeader renders header with one activity 1`] = `
       1 activity
     </h2>
   </div>
-  <div
-    className="c3"
-  />
 </div>
 `;
 
@@ -385,14 +383,6 @@ exports[`ActivityFeedHeader renders header without props 1`] = `
 .c1 > h2 {
   font-weight: normal;
   font-size: 28px;
-  margin-bottom: 0;
-}
-
-.c3 {
-  text-align: right;
-}
-
-.c3 > button {
   margin-bottom: 0;
 }
 
@@ -445,8 +435,5 @@ exports[`ActivityFeedHeader renders header without props 1`] = `
       Activities
     </h2>
   </div>
-  <div
-    className="c3"
-  />
 </div>
 `;

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -11,6 +11,9 @@ export {
 export {
   default as ActivityFeedPagination,
 } from './activity-feed/ActivityFeedPagination'
+export {
+  default as ActivityFeedAction,
+} from './activity-feed/ActivityFeedAction'
 
 // Address search
 export { default as useAddressSearch } from './address-search/useAddressSearch'


### PR DESCRIPTION
This PR does 3 things:
1. BREAKING CHANGE: change `contentText` and `contentLink`, which are used to populate the `Add interaction` button, to an array of JSX buttons. These can be defined in the implementation to allow flexibility to add `onClick` functions and the like. I have also provided an example button component called `ActivityFeedButton` which serves our current purposes. 
2. update the styling of the button to give the appropriate borders for desktop and mobile.  
3. refactor ActivityFeedHeader from a class to a functional component. 

In future PRs I am planning to continue to refactor the ActivityFeed to use functional components across all files and to lift the state out so that it can be used with Redux or any other state management. 