### PR TITLE
feat: Add date component

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -1,11 +1,9 @@
 module.exports = {
-    presets: [
-        "@babel/env",
-        "@babel/react"
-      ],
-      plugins: [
-        "@babel/plugin-proposal-class-properties",
-        "@babel/plugin-transform-runtime",
-        '@babel/plugin-proposal-optional-chaining'
-    ],
+  plugins: [
+    '@babel/plugin-proposal-class-properties',
+    '@babel/plugin-transform-runtime',
+    '@babel/plugin-proposal-optional-chaining',
+    '@babel/plugin-proposal-nullish-coalescing-operator',
+  ],
+  presets: ['@babel/env', '@babel/react'],
 }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@babel/cli": "^7.4.3",
     "@babel/core": "^7.4.3",
     "@babel/plugin-proposal-class-properties": "^7.4.3",
+    "@babel/plugin-proposal-nullish-coalescing-operator": "^7.8.3",
     "@babel/plugin-proposal-optional-chaining": "^7.8.3",
     "@babel/plugin-syntax-flow": "^7.2.0",
     "@babel/plugin-transform-runtime": "^7.4.4",

--- a/src/forms/elements/FieldDate.jsx
+++ b/src/forms/elements/FieldDate.jsx
@@ -1,0 +1,157 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import moment from 'moment'
+import { castArray } from 'lodash'
+import styled from 'styled-components'
+import { ERROR_COLOUR } from 'govuk-colours'
+import ErrorText from '@govuk-react/error-text'
+import Label from '@govuk-react/label'
+import Input from '@govuk-react/input'
+import LabelText from '@govuk-react/label-text'
+import {
+  BORDER_WIDTH_FORM_ELEMENT_ERROR,
+  SPACING,
+} from '@govuk-react/constants'
+
+import FieldWrapper from './FieldWrapper'
+import useField from '../hooks/useField'
+import { useFormContext } from '../..'
+
+const VALIDATION_DATE_FORMAT = 'YYYY-MM-DD'
+const DAY = 'day'
+const MONTH = 'month'
+const YEAR = 'year'
+
+const StyledInputWrapper = styled('div')`
+  ${(props) =>
+    props.error &&
+    `
+    border-left: ${BORDER_WIDTH_FORM_ELEMENT_ERROR} solid ${ERROR_COLOUR};
+    margin-right: ${SPACING.SCALE_3};
+    padding-left: ${SPACING.SCALE_2};
+  `}
+`
+
+const StyledLabel = styled(Label)(
+  {
+    marginRight: '20px',
+    marginBottom: 0,
+  },
+  ({ year }) => ({
+    width: year ? '70px' : '50px',
+  })
+)
+
+const StyledList = styled('div')({
+  display: 'flex',
+})
+
+const getValidator = (required) => ({ day, month, year }) => {
+  const isDateValid = moment(
+    `${year}-${month}-${day}`,
+    VALIDATION_DATE_FORMAT,
+    true
+  ).isValid()
+  const isDateEmpty = !day && !month && !year
+
+  return !isDateValid && (!isDateEmpty || required)
+    ? required || 'Enter a valid date'
+    : null
+}
+
+const FieldDate = ({ name, label, hint, validate, labels, required }) => {
+  const { value, error, touched, onBlur } = useField({
+    name,
+    initialValue: {
+      day: '',
+      month: '',
+      year: '',
+    },
+    validate: [getValidator(required), ...castArray(validate)],
+  })
+
+  const { setFieldValue } = useFormContext()
+
+  const onChange = (valueKey, e) => {
+    setFieldValue(name, {
+      ...value,
+      [valueKey]: e.target.value,
+    })
+  }
+
+  return (
+    <FieldWrapper {...{ name, label, hint, error }}>
+      <StyledInputWrapper error={error}>
+        {error && <ErrorText>{error}</ErrorText>}
+        <StyledList>
+          <StyledLabel>
+            <LabelText>{labels.day}</LabelText>
+            <Input
+              id={`${name}.day`}
+              name={`${name}.day`}
+              error={touched && error}
+              type="number"
+              value={value.day}
+              onChange={(e) => onChange(DAY, e)}
+              onBlur={onBlur}
+            />
+          </StyledLabel>
+          <StyledLabel>
+            <LabelText>{labels.month}</LabelText>
+            <Input
+              id={`${name}.month`}
+              name={`${name}.month`}
+              error={touched && error}
+              type="number"
+              value={value.month}
+              onChange={(e) => onChange(MONTH, e)}
+              onBlur={onBlur}
+            />
+          </StyledLabel>
+          <StyledLabel year={true}>
+            <LabelText>{labels.year}</LabelText>
+            <Input
+              id={`${name}.year`}
+              name={`${name}.year`}
+              error={touched && error}
+              type="number"
+              value={value.year}
+              onChange={(e) => onChange(YEAR, e)}
+              onBlur={onBlur}
+            />
+          </StyledLabel>
+        </StyledList>
+      </StyledInputWrapper>
+    </FieldWrapper>
+  )
+}
+
+FieldDate.propTypes = {
+  name: PropTypes.string.isRequired,
+  label: PropTypes.node,
+  hint: PropTypes.string,
+  required: PropTypes.string,
+  validate: PropTypes.oneOfType([
+    PropTypes.func,
+    PropTypes.arrayOf(PropTypes.func),
+  ]),
+  labels: PropTypes.shape({
+    day: PropTypes.string,
+    month: PropTypes.string,
+    year: PropTypes.string,
+  }),
+}
+
+FieldDate.defaultProps = {
+  label: null,
+  hint: null,
+  required: null,
+  validate: null,
+  labels: {
+    day: 'Day',
+    month: 'Month',
+    year: 'Year',
+  },
+}
+
+export default FieldDate

--- a/src/forms/elements/__stories__/FieldDate.stories.jsx
+++ b/src/forms/elements/__stories__/FieldDate.stories.jsx
@@ -1,0 +1,57 @@
+import React from 'react'
+import { addDecorator, storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions/dist/index'
+import { withKnobs } from '@storybook/addon-knobs'
+import Button from '@govuk-react/button'
+
+import FieldDate from '../FieldDate'
+import FormStateful from '../FormStateful'
+
+addDecorator(withKnobs)
+
+const ERRORS = {
+  DAY: 'Enter a valid Epoch day',
+  MONTH: 'Enter a valid Epoch month',
+  YEAR: 'Enter a valid Epoch year',
+}
+
+storiesOf('Forms', module)
+  .add('FieldDate - default validation', () => (
+    <FormStateful onSubmit={action('onSubmit')}>
+      {(form) => (
+        <>
+          <FieldDate
+            name="date"
+            label="What is your date of birth?"
+            hint="For example, 01 09 2019"
+            required="Enter a valid date of birth"
+          />
+          <Button>Submit</Button>
+          <pre>{JSON.stringify(form, null, 2)}</pre>
+        </>
+      )}
+    </FormStateful>
+  ))
+  .add('FieldDate - custom validation', () => (
+    <FormStateful onSubmit={action('onSubmit')}>
+      {(form) => (
+        <>
+          <FieldDate
+            name="date"
+            label="What date is Unix epoch?"
+            hint="For example, 01 09 2019"
+            required="Enter a valid Unix epoch date"
+            validate={({ day, month, year }) => {
+              // Contrived example
+              const dayErr = day === '01' ? null : ERRORS.DAY
+              const monthErr = month === '01' ? null : ERRORS.MONTH
+              const yearErr = year === '1970' ? null : ERRORS.YEAR
+              return dayErr || monthErr || yearErr
+            }}
+          />
+          <Button>Submit</Button>
+          <pre>{JSON.stringify(form, null, 2)}</pre>
+        </>
+      )}
+    </FormStateful>
+  ))

--- a/src/forms/elements/__tests__/FieldDate.test.jsx
+++ b/src/forms/elements/__tests__/FieldDate.test.jsx
@@ -1,0 +1,292 @@
+import React from 'react'
+import { mount } from 'enzyme'
+import HintText from '@govuk-react/hint-text'
+import Label from '@govuk-react/label'
+import ErrorText from '@govuk-react/error-text'
+
+import FieldDate from '../FieldDate'
+import FieldWrapper from '../FieldWrapper'
+import FormStateful from '../FormStateful'
+
+const assertDefaultAttributes = (input, key) => {
+  expect(input.prop('id')).toEqual(`date.${key}`)
+  expect(input.prop('name')).toEqual(`date.${key}`)
+  expect(input.prop('error')).toEqual(undefined)
+  expect(input.prop('type')).toEqual('number')
+  expect(input.prop('value')).toEqual('')
+  expect(input.prop('onBlur')).toBeInstanceOf(Function)
+  expect(input.prop('onChange')).toBeInstanceOf(Function)
+}
+
+describe('FieldDate', () => {
+  let wrapper
+
+  describe('when the date is mounted', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate name="date" />
+        </FormStateful>
+      )
+    })
+
+    test('should contain 3 inputs', () => {
+      const input = wrapper.find('input[type="number"]')
+      expect(input.length).toEqual(3)
+    })
+
+    test('should set the default attributes on the "day" input', () => {
+      const dayInput = wrapper.find('input[type="number"]').at(0)
+      assertDefaultAttributes(dayInput, 'day')
+    })
+
+    test('should set the default attributes on the "month" input', () => {
+      const dayInput = wrapper.find('input[type="number"]').at(1)
+      assertDefaultAttributes(dayInput, 'month')
+    })
+
+    test('should set the default attributes on the "year" input', () => {
+      const dayInput = wrapper.find('input[type="number"]').at(2)
+      assertDefaultAttributes(dayInput, 'year')
+    })
+  })
+
+  describe('when the date specifies a label', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate name="date" label="What is your DOB?" />
+        </FormStateful>
+      )
+    })
+
+    test('should render the date with a label', () => {
+      const label = wrapper.find(Label).at(0)
+      expect(label.text()).toEqual('What is your DOB?')
+    })
+  })
+
+  describe('when the date does not specify a label', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate name="testField" />
+        </FormStateful>
+      )
+    })
+
+    test('should render the date without a label', () => {
+      const label = wrapper.find(Label).at(0)
+      expect(label.text()).not.toEqual('What is your DOB?')
+    })
+  })
+
+  describe('when the date labels are all defaults', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate name="date" />
+        </FormStateful>
+      )
+    })
+
+    test('should render the day label', () => {
+      const label = wrapper.find(Label).at(0)
+      expect(label.text()).toEqual('Day')
+    })
+
+    test('should render the month label', () => {
+      const label = wrapper.find(Label).at(1)
+      expect(label.text()).toEqual('Month')
+    })
+
+    test('should render the year label', () => {
+      const label = wrapper.find(Label).at(2)
+      expect(label.text()).toEqual('Year')
+    })
+  })
+
+  describe('when the date labels are user defined', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate
+            name="date"
+            labels={{ day: 'DD', month: 'MM', year: 'YYYY' }}
+          />
+        </FormStateful>
+      )
+    })
+
+    test('should render the day label', () => {
+      const label = wrapper.find(Label).at(0)
+      expect(label.text()).toEqual('DD')
+    })
+
+    test('should render the month label', () => {
+      const label = wrapper.find(Label).at(1)
+      expect(label.text()).toEqual('MM')
+    })
+
+    test('should render the year label', () => {
+      const label = wrapper.find(Label).at(2)
+      expect(label.text()).toEqual('YYYY')
+    })
+  })
+
+  describe('when the date specifies a hint', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate name="date" hint="For example, 01 09 2019" />
+        </FormStateful>
+      )
+    })
+
+    test('should render the date with a hint', () => {
+      expect(wrapper.find(HintText).text()).toEqual('For example, 01 09 2019')
+    })
+  })
+
+  describe('when the field does not specify a hint', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate name="date" />
+        </FormStateful>
+      )
+    })
+
+    test('should not render a hint', () => {
+      expect(wrapper.find(HintText).exists()).toBe(false)
+    })
+  })
+
+  describe('when custom validation passes', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate
+            name="date"
+            // eslint-disable-next-line no-unused-vars
+            validate={(date) => {
+              // Validate the date by returning null
+              return null
+            }}
+          />
+        </FormStateful>
+      )
+      wrapper.find('form').simulate('submit')
+    })
+
+    test('should not render an error message', () => {
+      expect(wrapper.find(ErrorText).exists()).toBe(false)
+    })
+  })
+
+  describe('when custom validation fails', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate
+            name="date"
+            // eslint-disable-next-line no-unused-vars
+            validate={(date) => {
+              // Invalidate the date by returning an error String
+              return 'Enter a valid date (custom)'
+            }}
+          />
+        </FormStateful>
+      )
+      wrapper.find('form').simulate('submit')
+    })
+
+    test('should render an error message', () => {
+      expect(wrapper.find(ErrorText).text()).toEqual(
+        'Enter a valid date (custom)'
+      )
+    })
+
+    test('should render error styles', () => {
+      const inputWrapper = wrapper
+        .find(FieldWrapper)
+        .find('div')
+        .at(1)
+      expect(inputWrapper).toHaveStyleRule('border-left', '4px solid #b10e1e')
+      expect(inputWrapper).toHaveStyleRule('margin-right', '15px')
+      expect(inputWrapper).toHaveStyleRule('padding-left', '10px')
+    })
+  })
+
+  describe('when default validation fails', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          <FieldDate name="date" />
+        </FormStateful>
+      )
+
+      const dayInput = wrapper.find('input[type="number"]').at(0)
+      const monthInput = wrapper.find('input[type="number"]').at(1)
+      const yearInput = wrapper.find('input[type="number"]').at(2)
+
+      dayInput.simulate('change', { target: { value: '29' } })
+      monthInput.simulate('change', { target: { value: '02' } })
+      yearInput.simulate('change', { target: { value: '2019' } })
+
+      wrapper.find('form').simulate('submit')
+    })
+
+    test('should render an error message', () => {
+      expect(wrapper.find(ErrorText).text()).toEqual('Enter a valid date')
+    })
+  })
+
+  describe('when Day, Month and Year is typed into the date fields', () => {
+    beforeAll(() => {
+      wrapper = mount(
+        <FormStateful>
+          {(state) => (
+            <>
+              <FieldDate name="date" />
+              <div id="values">{JSON.stringify(state.values.date)}</div>
+            </>
+          )}
+        </FormStateful>
+      )
+
+      const dayInput = wrapper.find('input[type="number"]').at(0)
+      const monthInput = wrapper.find('input[type="number"]').at(1)
+      const yearInput = wrapper.find('input[type="number"]').at(2)
+
+      dayInput.simulate('change', { target: { value: '01' } })
+      monthInput.simulate('change', { target: { value: '25' } })
+      yearInput.simulate('change', { target: { value: '2019' } })
+    })
+
+    test('should update the day value', () => {
+      const dayInput = wrapper.find('input[type="number"]').at(0)
+      expect(dayInput.prop('value')).toEqual('01')
+    })
+
+    test('should update the month value', () => {
+      const monthInput = wrapper.find('input[type="number"]').at(1)
+      expect(monthInput.prop('value')).toEqual('25')
+    })
+
+    test('should update year value', () => {
+      const yearInput = wrapper.find('input[type="number"]').at(2)
+      expect(yearInput.prop('value')).toEqual('2019')
+    })
+
+    test('should update value in form state', () => {
+      const values = wrapper.find('#values')
+      const date = JSON.parse(values.text())
+      expect(date).toEqual({
+        day: '01',
+        month: '25',
+        year: '2019',
+      })
+    })
+  })
+})

--- a/src/forms/hooks/__tests__/useForm.test.jsx
+++ b/src/forms/hooks/__tests__/useForm.test.jsx
@@ -121,7 +121,7 @@ describe('useForm', () => {
       const hook = renderHook(() => useForm())
 
       act(() => {
-        fieldState = hook.result.current.getFieldState('testField1')
+        fieldState = hook.result.current.getFieldState('testField1', '')
       })
     })
 

--- a/src/forms/hooks/useField.js
+++ b/src/forms/hooks/useField.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react'
-import { isEmpty } from 'lodash'
+import { isEmpty, castArray } from 'lodash'
 
 import useFormContext from './useFormContext'
 
@@ -18,9 +18,7 @@ function useField({
   } = useFormContext()
 
   function prepareValidators() {
-    const validators = Array.isArray(validate)
-      ? validate
-      : [validate].filter((v) => v)
+    const validators = castArray(validate).filter((v) => v)
 
     if (required) {
       validators.unshift((value) => (isEmpty(value) ? required : null))
@@ -37,7 +35,7 @@ function useField({
     }
   }, [name])
 
-  const fieldState = getFieldState(name)
+  const fieldState = getFieldState(name, initialValue)
 
   return {
     name,

--- a/src/forms/hooks/useForm.js
+++ b/src/forms/hooks/useForm.js
@@ -75,9 +75,9 @@ function useForm({
     }
   }, [currentStep, errors])
 
-  const getFieldState = (name) => {
+  const getFieldState = (name, initialState) => {
     return {
-      value: values[name] || '',
+      value: values[name] ?? initialState,
       touched: touched[name] || false,
       error: errors[name] || null,
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -288,6 +288,14 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
+"@babel/plugin-proposal-nullish-coalescing-operator@^7.8.3":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-nullish-coalescing-operator/-/plugin-proposal-nullish-coalescing-operator-7.8.3.tgz#e4572253fdeed65cddeecfdab3f928afeb2fd5d2"
+  integrity sha512-TS9MlfzXpXKt6YYomudb/KU7nQI6/xnapG6in1uZxoxDghuSMZsPb6D2fyUwNYSAp4l1iR7QtFOjkqcRYcUsfw==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.3"
+    "@babel/plugin-syntax-nullish-coalescing-operator" "^7.8.0"
+
 "@babel/plugin-proposal-object-rest-spread@7.4.3":
   version "7.4.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.3.tgz#be27cd416eceeba84141305b93c282f5de23bbb4"
@@ -360,6 +368,13 @@
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.2.0.tgz#0b85a3b4bc7cdf4cc4b8bf236335b907ca22e7c7"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
+
+"@babel/plugin-syntax-nullish-coalescing-operator@^7.8.0":
+  version "7.8.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-nullish-coalescing-operator/-/plugin-syntax-nullish-coalescing-operator-7.8.3.tgz#167ed70368886081f74b5c36c65a88c03b66d1a9"
+  integrity sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.8.0"
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0", "@babel/plugin-syntax-object-rest-spread@^7.2.0":
   version "7.2.0"
@@ -4768,7 +4783,7 @@ debug@^4.0.0, debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
   dependencies:
     ms "^2.1.1"
 
-debuglog@*, debuglog@^1.0.1:
+debuglog@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/debuglog/-/debuglog-1.0.1.tgz#aa24ffb9ac3df9a2351837cfb2d279360cd78492"
   integrity sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
@@ -6810,7 +6825,7 @@ import-local@2.0.0, import-local@^2.0.0:
     pkg-dir "^3.0.0"
     resolve-cwd "^2.0.0"
 
-imurmurhash@*, imurmurhash@^0.1.4:
+imurmurhash@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/imurmurhash/-/imurmurhash-0.1.4.tgz#9218b9b2b928a238b13dc4fb6b6d576f231453ea"
   integrity sha1-khi5srkoojixPcT7a21XbyMUU+o=
@@ -8151,11 +8166,6 @@ lodash-es@^4.17.11:
   version "4.17.14"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.14.tgz#12a95a963cc5955683cee3b74e85458954f37ecc"
 
-lodash._baseindexof@*:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/lodash._baseindexof/-/lodash._baseindexof-3.1.0.tgz#fe52b53a1c6761e42618d654e4a25789ed61822c"
-  integrity sha1-/lK1OhxnYeQmGNZU5KJXie1hgiw=
-
 lodash._baseuniq@~4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/lodash._baseuniq/-/lodash._baseuniq-4.6.0.tgz#0ebb44e456814af7905c6212fa2c9b2d51b841e8"
@@ -8164,32 +8174,10 @@ lodash._baseuniq@~4.6.0:
     lodash._createset "~4.0.0"
     lodash._root "~3.0.0"
 
-lodash._bindcallback@*:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash._bindcallback/-/lodash._bindcallback-3.0.1.tgz#e531c27644cf8b57a99e17ed95b35c748789392e"
-  integrity sha1-5THCdkTPi1epnhftlbNcdIeJOS4=
-
-lodash._cacheindexof@*:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/lodash._cacheindexof/-/lodash._cacheindexof-3.0.2.tgz#3dc69ac82498d2ee5e3ce56091bafd2adc7bde92"
-  integrity sha1-PcaayCSY0u5ePOVgkbr9Ktx73pI=
-
-lodash._createcache@*:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/lodash._createcache/-/lodash._createcache-3.1.2.tgz#56d6a064017625e79ebca6b8018e17440bdcf093"
-  integrity sha1-VtagZAF2JeeevKa4AY4XRAvc8JM=
-  dependencies:
-    lodash._getnative "^3.0.0"
-
 lodash._createset@~4.0.0:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/lodash._createset/-/lodash._createset-4.0.3.tgz#0f4659fbb09d75194fa9e2b88a6644d363c9fe26"
   integrity sha1-D0ZZ+7CddRlPqeK4imZE02PJ/iY=
-
-lodash._getnative@*, lodash._getnative@^3.0.0:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/lodash._getnative/-/lodash._getnative-3.9.1.tgz#570bc7dede46d61cdcde687d65d3eecbaa3aaff5"
-  integrity sha1-VwvH3t5G1hzc3mh9ZdPuy6o6r/U=
 
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
@@ -8252,11 +8240,6 @@ lodash.map@^4.5.1:
 lodash.memoize@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/lodash.memoize/-/lodash.memoize-4.1.2.tgz#bcc6c49a42a2840ed997f323eada5ecd182e0bfe"
-
-lodash.restparam@*:
-  version "3.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
-  integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
 lodash.set@^4.3.2:
   version "4.3.2"
@@ -9247,7 +9230,6 @@ npm@^6.8.0:
     cmd-shim "^3.0.3"
     columnify "~1.5.4"
     config-chain "^1.1.12"
-    debuglog "*"
     detect-indent "~5.0.0"
     detect-newline "^2.1.0"
     dezalgo "~1.0.3"
@@ -9262,7 +9244,6 @@ npm@^6.8.0:
     has-unicode "~2.0.1"
     hosted-git-info "^2.8.8"
     iferr "^1.0.2"
-    imurmurhash "*"
     infer-owner "^1.0.4"
     inflight "~1.0.6"
     inherits "^2.0.4"
@@ -9281,14 +9262,8 @@ npm@^6.8.0:
     libnpx "^10.2.2"
     lock-verify "^2.1.0"
     lockfile "^1.0.4"
-    lodash._baseindexof "*"
     lodash._baseuniq "~4.6.0"
-    lodash._bindcallback "*"
-    lodash._cacheindexof "*"
-    lodash._createcache "*"
-    lodash._getnative "*"
     lodash.clonedeep "~4.5.0"
-    lodash.restparam "*"
     lodash.union "~4.6.0"
     lodash.uniq "~4.5.0"
     lodash.without "~4.4.0"


### PR DESCRIPTION
# Date component
A new date component that allows default and custom validation of dates. 

## Default validation
<img width="277" alt="1" src="https://user-images.githubusercontent.com/964268/77317803-ca9f7a00-6d03-11ea-8fbd-b82e054715cf.png">

### User enters an invalid date
<img width="277" alt="2" src="https://user-images.githubusercontent.com/964268/77317815-d25f1e80-6d03-11ea-9dfb-894f7273e146.png">

### User submits a valid date
<img width="277" alt="3" src="https://user-images.githubusercontent.com/964268/77317834-dbe88680-6d03-11ea-8c32-c06ca7147736.png">

## Custom validation (contrived example)
<img width="287" alt="1" src="https://user-images.githubusercontent.com/964268/77190834-de639a00-6ad1-11ea-8437-0f25c8a5ced0.png">

### User submits without entering a valid date
<img width="334" alt="1" src="https://user-images.githubusercontent.com/964268/77303458-eb0f0a80-6cea-11ea-88e6-c80c0d19fb5b.png">

### User submits without entering a valid day
<img width="334" alt="2" src="https://user-images.githubusercontent.com/964268/77303573-172a8b80-6ceb-11ea-898c-4208e1870c8a.png">

### User submits without entering a valid month
<img width="334" alt="3" src="https://user-images.githubusercontent.com/964268/77303647-33c6c380-6ceb-11ea-9c24-510726d6d9c7.png">

### User submits without entering a valid year
<img width="334" alt="4" src="https://user-images.githubusercontent.com/964268/77303737-5953cd00-6ceb-11ea-99cd-3d6c34bc1504.png">

### User submits correct date
<img width="302" alt="6" src="https://user-images.githubusercontent.com/964268/77191477-ed971780-6ad2-11ea-8f17-f8e697b92440.png">
