### PR TITLE
fix: update help text for NewWindowLink

### DIFF
--- a/src/new-window-link/NewWindowLink.jsx
+++ b/src/new-window-link/NewWindowLink.jsx
@@ -7,12 +7,12 @@ const NewWindowLink = ({ href, children, ...rest }) => (
     <Link
       href={href}
       target="_blank"
-      aria-label="Opens in a new window"
+      aria-label="Opens in a new window or tab"
       {...rest}
     >
       {children}
     </Link>{' '}
-    (Opens in a new window)
+    {showHelpText && '(opens in a new window or tab)'}
   </>
 )
 

--- a/src/new-window-link/NewWindowLink.jsx
+++ b/src/new-window-link/NewWindowLink.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 import Link from '@govuk-react/link'
 import PropTypes from 'prop-types'
 
-const NewWindowLink = ({ href, children, ...rest }) => (
+const NewWindowLink = ({ href, showHelpText, children, ...rest }) => (
   <>
     <Link
       href={href}
@@ -18,7 +18,12 @@ const NewWindowLink = ({ href, children, ...rest }) => (
 
 NewWindowLink.propTypes = {
   href: PropTypes.string.isRequired,
+  showHelpText: PropTypes.bool,
   children: PropTypes.node.isRequired,
+}
+
+NewWindowLink.defaultProps = {
+  showHelpText: true,
 }
 
 export default NewWindowLink

--- a/src/new-window-link/__tests__/NewWindowLink.test.jsx
+++ b/src/new-window-link/__tests__/NewWindowLink.test.jsx
@@ -15,10 +15,15 @@ describe('NewWindowLink', () => {
 
     test('should render the link', () => {
       const linkAttrs = wrapper.find('a').props()
-      expect(linkAttrs).toHaveProperty('aria-label', 'Opens in a new window')
+      expect(linkAttrs).toHaveProperty(
+        'aria-label',
+        'Opens in a new window or tab'
+      )
       expect(linkAttrs).toHaveProperty('href', 'https://example.com')
       expect(linkAttrs).toHaveProperty('target', '_blank')
-      expect(wrapper.text()).toEqual('testChildren (Opens in a new window)')
+      expect(wrapper.text()).toEqual(
+        'testChildren (opens in a new window or tab)'
+      )
     })
   })
 })


### PR DESCRIPTION
This PR makes the help text which shows after a NewWindowLink optional using a 'showHelpText' prop, which defaults to true. It also updates the content of the help text:

Current help text: _(Opens in a new window)_
New help text: (opens in a new window or tab)
