### PR TITLE
fix: Fix setting of initial field value

### DIFF
--- a/src/forms/hooks/__tests__/useForm.test.jsx
+++ b/src/forms/hooks/__tests__/useForm.test.jsx
@@ -174,6 +174,25 @@ describe('useForm', () => {
     })
   })
 
+  describe('when registerField() is called and the value for that field already exists', () => {
+    beforeAll(async () => {
+      const hook = renderHook(() =>
+        useForm({ initialValues: { testField1: 'testPreExistingValue' } })
+      )
+
+      await act(async () => {
+        await hook.result.current.registerField(testField1)
+        formState = hook.result.current
+      })
+    })
+
+    test('should not override the pre-existing value', () => {
+      expect(formState.values).toEqual({
+        testField1: 'testPreExistingValue',
+      })
+    })
+  })
+
   describe('when deregisterField() is called', () => {
     beforeAll(async () => {
       const hook = renderHook(() => useForm())

--- a/src/forms/hooks/useForm.js
+++ b/src/forms/hooks/useForm.js
@@ -145,7 +145,7 @@ function useForm({
     setFields((prevFields) => {
       const { name, initialValue } = field
 
-      if (initialValue) {
+      if (initialValue && values[name] === undefined) {
         setFieldValue(name, initialValue)
       }
 


### PR DESCRIPTION
Fix an edge case where initial value for a field was overriding the values passed with the `Form` component.