### PR TITLE
fix: Override box shadow on Typeahead input text

### DIFF
--- a/src/typeahead/styles.js
+++ b/src/typeahead/styles.js
@@ -44,6 +44,7 @@ const defaultStyles = {
   control: (styles, { isFocused }) => ({
     ...styles,
     borderRadius: 0,
+    'input:focus': { boxShadow: 'none' },
     outline: isFocused ? `3px solid ${YELLOW}` : styles.outline,
     border: `2px solid ${BLACK}`,
     '&:hover': {


### PR DESCRIPTION
Data Hub front end has a global style which puts a box-shadow on inputs. This means that when the TypeAhead component is used in the front end, there is a yellow outline around the text in the hidden input element. 

This PR overrides this by setting box-shadow to none for the input within the typeahead.

I have made this change in the typeahead component itself, rather than the front end's global styles, as the box shadow may be needed for other input elements in the front end. 

## Before

![Screenshot 2020-03-27 at 12 42 29](https://user-images.githubusercontent.com/22460823/77757380-0fd7ea80-7029-11ea-99c2-e31edd30ade7.png)


## After

![Screenshot 2020-03-27 at 12 42 41](https://user-images.githubusercontent.com/22460823/77757399-16666200-7029-11ea-883e-08170307c9e5.png)

## How to test

Using [yalc](https://www.npmjs.com/package/yalc) to point the front end repo to this branch 

- Switch to this branch 
- Run `yalc publish `
- In the front end repo run `yalc data-hub-components`
- Go to interactions/create/companyId
- Check that there is no yellow outline on the typeaheads' input text
