### PR TITLE
Move styled-components to peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,12 +78,12 @@
     "react-markdown": "^4.0.8",
     "react-select": "^3.0.8",
     "react-string-replace": "^0.4.4",
-    "react-use": "^12.2.0",
-    "styled-components": "^4.2.0"
+    "react-use": "^12.2.0"
   },
   "peerDependencies": {
     "react": "*",
-    "react-dom": "*"
+    "react-dom": "*",
+    "styled-components": "*"
   },
   "devDependencies": {
     "@babel/cli": "^7.4.3",
@@ -133,6 +133,7 @@
     "react-test-renderer": "^16.9.0",
     "rimraf": "^2.6.3",
     "semantic-release": "^15.13.18",
+    "styled-components": "^4.2.0",
     "webpack": "^4.29.6",
     "webpack-cli": "^3.3.0"
   },

--- a/src/activity-feed/__tests__/__snapshots__/Activity.test.jsx.snap
+++ b/src/activity-feed/__tests__/__snapshots__/Activity.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`Activity when a New OMIS order is added should render an activity card 
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -125,22 +125,22 @@ exports[`Activity when a New OMIS order is added should render an activity card 
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -163,7 +163,7 @@ exports[`Activity when a New OMIS order is added should render an activity card 
   margin-bottom: 5px;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   font-weight: normal;
   color: white;
@@ -234,7 +234,7 @@ exports[`Activity when a New OMIS order is added should render an activity card 
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -248,12 +248,12 @@ exports[`Activity when a New OMIS order is added should render an activity card 
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -261,7 +261,7 @@ exports[`Activity when a New OMIS order is added should render an activity card 
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -275,15 +275,15 @@ exports[`Activity when a New OMIS order is added should render an activity card 
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c8 {
+.c20 > .c8 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -298,27 +298,27 @@ exports[`Activity when a New OMIS order is added should render an activity card 
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -340,33 +340,33 @@ exports[`Activity when a New OMIS order is added should render an activity card 
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -408,59 +408,59 @@ exports[`Activity when a New OMIS order is added should render an activity card 
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -501,7 +501,7 @@ exports[`Activity when a New OMIS order is added should render an activity card 
         New Order (OMIS) added
       </h3>
       <h3
-        className="c5 c4"
+        className="c3 c5"
         size="MEDIUM"
       >
         <a
@@ -704,7 +704,7 @@ exports[`Activity when an investment project is CTI should render the CTI invest
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -823,22 +823,22 @@ exports[`Activity when an investment project is CTI should render the CTI invest
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -861,7 +861,7 @@ exports[`Activity when an investment project is CTI should render the CTI invest
   margin-bottom: 5px;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   font-weight: normal;
   color: white;
@@ -932,7 +932,7 @@ exports[`Activity when an investment project is CTI should render the CTI invest
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -946,12 +946,12 @@ exports[`Activity when an investment project is CTI should render the CTI invest
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -959,7 +959,7 @@ exports[`Activity when an investment project is CTI should render the CTI invest
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -973,15 +973,15 @@ exports[`Activity when an investment project is CTI should render the CTI invest
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c8 {
+.c20 > .c8 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -996,27 +996,27 @@ exports[`Activity when an investment project is CTI should render the CTI invest
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -1038,33 +1038,33 @@ exports[`Activity when an investment project is CTI should render the CTI invest
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -1106,59 +1106,59 @@ exports[`Activity when an investment project is CTI should render the CTI invest
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -1199,7 +1199,7 @@ exports[`Activity when an investment project is CTI should render the CTI invest
         New investment project added - Commitment to invest
       </h3>
       <h3
-        className="c5 c4"
+        className="c3 c5"
         size="MEDIUM"
       >
         <a
@@ -1358,7 +1358,7 @@ exports[`Activity when an investment project is FDI should render the FDI invest
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -1477,22 +1477,22 @@ exports[`Activity when an investment project is FDI should render the FDI invest
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -1515,7 +1515,7 @@ exports[`Activity when an investment project is FDI should render the FDI invest
   margin-bottom: 5px;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   font-weight: normal;
   color: white;
@@ -1586,7 +1586,7 @@ exports[`Activity when an investment project is FDI should render the FDI invest
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -1600,12 +1600,12 @@ exports[`Activity when an investment project is FDI should render the FDI invest
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -1613,7 +1613,7 @@ exports[`Activity when an investment project is FDI should render the FDI invest
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -1627,15 +1627,15 @@ exports[`Activity when an investment project is FDI should render the FDI invest
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c8 {
+.c20 > .c8 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -1650,27 +1650,27 @@ exports[`Activity when an investment project is FDI should render the FDI invest
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -1692,33 +1692,33 @@ exports[`Activity when an investment project is FDI should render the FDI invest
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -1760,59 +1760,59 @@ exports[`Activity when an investment project is FDI should render the FDI invest
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -1853,7 +1853,7 @@ exports[`Activity when an investment project is FDI should render the FDI invest
         New investment project added - FDI
       </h3>
       <h3
-        className="c5 c4"
+        className="c3 c5"
         size="MEDIUM"
       >
         <a
@@ -2146,7 +2146,7 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -2265,22 +2265,22 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -2303,7 +2303,7 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
   margin-bottom: 5px;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   font-weight: normal;
   color: white;
@@ -2374,7 +2374,7 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -2388,12 +2388,12 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -2401,7 +2401,7 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -2415,15 +2415,15 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c8 {
+.c20 > .c8 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -2438,27 +2438,27 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -2480,33 +2480,33 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -2548,59 +2548,59 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -2641,7 +2641,7 @@ exports[`Activity when an investment project is Non-FDI should render the Non-FD
         New investment project added - Non-FDI
       </h3>
       <h3
-        className="c5 c4"
+        className="c3 c5"
         size="MEDIUM"
       >
         <a
@@ -2844,7 +2844,7 @@ exports[`Activity when the interaction does not have a service should render int
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -2963,22 +2963,22 @@ exports[`Activity when the interaction does not have a service should render int
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -3023,15 +3023,15 @@ exports[`Activity when the interaction does not have a service should render int
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -3071,7 +3071,7 @@ exports[`Activity when the interaction does not have a service should render int
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -3085,12 +3085,12 @@ exports[`Activity when the interaction does not have a service should render int
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -3098,7 +3098,7 @@ exports[`Activity when the interaction does not have a service should render int
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -3112,40 +3112,40 @@ exports[`Activity when the interaction does not have a service should render int
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c7 {
+.c20 > .c7 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -3167,33 +3167,33 @@ exports[`Activity when the interaction does not have a service should render int
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -3223,7 +3223,7 @@ exports[`Activity when the interaction does not have a service should render int
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -3235,59 +3235,59 @@ exports[`Activity when the interaction does not have a service should render int
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -3429,7 +3429,7 @@ exports[`Activity when the interaction is a draft and archived should render int
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -3548,22 +3548,22 @@ exports[`Activity when the interaction is a draft and archived should render int
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -3608,15 +3608,15 @@ exports[`Activity when the interaction is a draft and archived should render int
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -3656,7 +3656,7 @@ exports[`Activity when the interaction is a draft and archived should render int
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -3670,12 +3670,12 @@ exports[`Activity when the interaction is a draft and archived should render int
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -3683,7 +3683,7 @@ exports[`Activity when the interaction is a draft and archived should render int
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -3697,15 +3697,15 @@ exports[`Activity when the interaction is a draft and archived should render int
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c7 {
+.c20 > .c7 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -3720,27 +3720,27 @@ exports[`Activity when the interaction is a draft and archived should render int
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -3762,33 +3762,33 @@ exports[`Activity when the interaction is a draft and archived should render int
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -3818,7 +3818,7 @@ exports[`Activity when the interaction is a draft and archived should render int
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -3830,59 +3830,59 @@ exports[`Activity when the interaction is a draft and archived should render int
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -4163,7 +4163,7 @@ exports[`Activity when the interaction is a draft and upcoming should render int
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -4282,22 +4282,22 @@ exports[`Activity when the interaction is a draft and upcoming should render int
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -4342,15 +4342,15 @@ exports[`Activity when the interaction is a draft and upcoming should render int
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -4390,7 +4390,7 @@ exports[`Activity when the interaction is a draft and upcoming should render int
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -4404,12 +4404,12 @@ exports[`Activity when the interaction is a draft and upcoming should render int
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -4417,7 +4417,7 @@ exports[`Activity when the interaction is a draft and upcoming should render int
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -4431,15 +4431,15 @@ exports[`Activity when the interaction is a draft and upcoming should render int
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c7 {
+.c20 > .c7 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -4454,27 +4454,27 @@ exports[`Activity when the interaction is a draft and upcoming should render int
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -4496,33 +4496,33 @@ exports[`Activity when the interaction is a draft and upcoming should render int
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -4552,7 +4552,7 @@ exports[`Activity when the interaction is a draft and upcoming should render int
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -4564,59 +4564,59 @@ exports[`Activity when the interaction is a draft and upcoming should render int
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -4897,7 +4897,7 @@ exports[`Activity when the interaction is a draft in the past should render inte
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -5016,22 +5016,22 @@ exports[`Activity when the interaction is a draft in the past should render inte
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -5076,15 +5076,15 @@ exports[`Activity when the interaction is a draft in the past should render inte
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -5124,7 +5124,7 @@ exports[`Activity when the interaction is a draft in the past should render inte
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -5138,12 +5138,12 @@ exports[`Activity when the interaction is a draft in the past should render inte
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -5151,7 +5151,7 @@ exports[`Activity when the interaction is a draft in the past should render inte
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -5165,15 +5165,15 @@ exports[`Activity when the interaction is a draft in the past should render inte
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c7 {
+.c20 > .c7 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -5188,27 +5188,27 @@ exports[`Activity when the interaction is a draft in the past should render inte
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -5230,33 +5230,33 @@ exports[`Activity when the interaction is a draft in the past should render inte
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -5286,7 +5286,7 @@ exports[`Activity when the interaction is a draft in the past should render inte
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -5298,59 +5298,59 @@ exports[`Activity when the interaction is a draft in the past should render inte
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -5631,7 +5631,7 @@ exports[`Activity when the interaction is complete should render interaction act
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -5750,22 +5750,22 @@ exports[`Activity when the interaction is complete should render interaction act
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -5810,15 +5810,15 @@ exports[`Activity when the interaction is complete should render interaction act
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -5858,7 +5858,7 @@ exports[`Activity when the interaction is complete should render interaction act
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -5872,12 +5872,12 @@ exports[`Activity when the interaction is complete should render interaction act
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -5885,7 +5885,7 @@ exports[`Activity when the interaction is complete should render interaction act
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -5899,15 +5899,15 @@ exports[`Activity when the interaction is complete should render interaction act
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c7 {
+.c20 > .c7 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -5922,27 +5922,27 @@ exports[`Activity when the interaction is complete should render interaction act
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -5964,33 +5964,33 @@ exports[`Activity when the interaction is complete should render interaction act
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -6020,7 +6020,7 @@ exports[`Activity when the interaction is complete should render interaction act
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -6032,59 +6032,59 @@ exports[`Activity when the interaction is complete should render interaction act
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -6365,7 +6365,7 @@ exports[`Activity when there is a Companies House Accounts record should render 
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -6484,22 +6484,22 @@ exports[`Activity when there is a Companies House Accounts record should render 
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -6522,7 +6522,7 @@ exports[`Activity when there is a Companies House Accounts record should render 
   margin-bottom: 5px;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   font-weight: normal;
   color: white;
@@ -6600,7 +6600,7 @@ exports[`Activity when there is a Companies House Accounts record should render 
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -6614,12 +6614,12 @@ exports[`Activity when there is a Companies House Accounts record should render 
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -6632,27 +6632,27 @@ exports[`Activity when there is a Companies House Accounts record should render 
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -6674,33 +6674,33 @@ exports[`Activity when there is a Companies House Accounts record should render 
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -6742,33 +6742,33 @@ exports[`Activity when there is a Companies House Accounts record should render 
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c16 {
+  .c15 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c16 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c16 {
+  .c15 {
     margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c15 {
+  .c16 {
     margin-bottom: 10px;
   }
 }
@@ -6794,7 +6794,7 @@ exports[`Activity when there is a Companies House Accounts record should render 
         Accounts records
       </span>
       <h3
-        className="c6 c4"
+        className="c3 c6"
         size="MEDIUM"
       >
         Company officially incorporated in Companies House.
@@ -6976,7 +6976,7 @@ exports[`Activity when there is a Companies House Company incorporation record s
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -7063,22 +7063,22 @@ exports[`Activity when there is a Companies House Company incorporation record s
   margin-bottom: 0;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -7101,7 +7101,7 @@ exports[`Activity when there is a Companies House Company incorporation record s
   margin-bottom: 5px;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   font-weight: normal;
   color: white;
@@ -7179,7 +7179,7 @@ exports[`Activity when there is a Companies House Company incorporation record s
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -7193,12 +7193,12 @@ exports[`Activity when there is a Companies House Company incorporation record s
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -7206,7 +7206,7 @@ exports[`Activity when there is a Companies House Company incorporation record s
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -7220,15 +7220,15 @@ exports[`Activity when there is a Companies House Company incorporation record s
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c8 {
+.c20 > .c8 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -7243,59 +7243,59 @@ exports[`Activity when there is a Companies House Company incorporation record s
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c11 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c10 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -7337,59 +7337,59 @@ exports[`Activity when there is a Companies House Company incorporation record s
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -7435,7 +7435,7 @@ exports[`Activity when there is a Companies House Company incorporation record s
         Company records
       </span>
       <h3
-        className="c6 c4"
+        className="c3 c6"
         size="MEDIUM"
       >
         SULTRAX officially did action number 10.
@@ -7679,7 +7679,7 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -7766,22 +7766,22 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
   margin-bottom: 0;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -7804,7 +7804,7 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
   margin-bottom: 5px;
 }
 
-.c3 {
+.c4 {
   display: inline-block;
   font-weight: normal;
   color: white;
@@ -7882,7 +7882,7 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -7896,12 +7896,12 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -7909,7 +7909,7 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -7923,15 +7923,15 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c8 {
+.c20 > .c8 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -7946,59 +7946,59 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c11 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c10 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -8040,59 +8040,59 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -8138,7 +8138,7 @@ exports[`Activity when there is a HMRC Exporter record should render an activity
         Exporters records
       </span>
       <h3
-        className="c6 c4"
+        className="c3 c6"
         size="MEDIUM"
       >
         The Water Company officially did action number 5.
@@ -8284,7 +8284,7 @@ exports[`Activity when there is a completed referral should render an complete r
   background-color: #ffbf47;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -8329,15 +8329,15 @@ exports[`Activity when there is a completed referral should render an complete r
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -8377,7 +8377,7 @@ exports[`Activity when there is a completed referral should render an complete r
   padding-right: 0;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -8391,12 +8391,12 @@ exports[`Activity when there is a completed referral should render an complete r
   margin-bottom: 20px;
 }
 
-.c10 th {
+.c11 th {
   width: 284px;
 }
 
-.c10 th,
-.c10 td {
+.c11 th,
+.c11 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -8425,27 +8425,27 @@ exports[`Activity when there is a completed referral should render an complete r
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -8475,7 +8475,7 @@ exports[`Activity when there is a completed referral should render an complete r
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -8487,33 +8487,33 @@ exports[`Activity when there is a completed referral should render an complete r
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-bottom: 0;
   }
 }
@@ -8699,7 +8699,7 @@ exports[`Activity when there is a outstanding referral should render an outstand
   background-color: #ffbf47;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -8744,15 +8744,15 @@ exports[`Activity when there is a outstanding referral should render an outstand
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -8792,7 +8792,7 @@ exports[`Activity when there is a outstanding referral should render an outstand
   padding-right: 0;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -8806,12 +8806,12 @@ exports[`Activity when there is a outstanding referral should render an outstand
   margin-bottom: 20px;
 }
 
-.c10 th {
+.c11 th {
   width: 284px;
 }
 
-.c10 th,
-.c10 td {
+.c11 th,
+.c11 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -8840,27 +8840,27 @@ exports[`Activity when there is a outstanding referral should render an outstand
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -8890,7 +8890,7 @@ exports[`Activity when there is a outstanding referral should render an outstand
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -8902,33 +8902,33 @@ exports[`Activity when there is a outstanding referral should render an outstand
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-bottom: 0;
   }
 }
@@ -9057,7 +9057,7 @@ exports[`Activity when there is a service delivery should render service deliver
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -9176,22 +9176,22 @@ exports[`Activity when there is a service delivery should render service deliver
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -9236,15 +9236,15 @@ exports[`Activity when there is a service delivery should render service deliver
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -9284,7 +9284,7 @@ exports[`Activity when there is a service delivery should render service deliver
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -9298,12 +9298,12 @@ exports[`Activity when there is a service delivery should render service deliver
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -9311,7 +9311,7 @@ exports[`Activity when there is a service delivery should render service deliver
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -9325,15 +9325,15 @@ exports[`Activity when there is a service delivery should render service deliver
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c7 {
+.c20 > .c7 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -9348,27 +9348,27 @@ exports[`Activity when there is a service delivery should render service deliver
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -9390,33 +9390,33 @@ exports[`Activity when there is a service delivery should render service deliver
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -9446,7 +9446,7 @@ exports[`Activity when there is a service delivery should render service deliver
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -9458,59 +9458,59 @@ exports[`Activity when there is a service delivery should render service deliver
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -9730,7 +9730,7 @@ exports[`Activity when there is an interaction should render interaction activit
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -9849,22 +9849,22 @@ exports[`Activity when there is an interaction should render interaction activit
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -9909,15 +9909,15 @@ exports[`Activity when there is an interaction should render interaction activit
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -9957,7 +9957,7 @@ exports[`Activity when there is an interaction should render interaction activit
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -9971,12 +9971,12 @@ exports[`Activity when there is an interaction should render interaction activit
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -9984,7 +9984,7 @@ exports[`Activity when there is an interaction should render interaction activit
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -9998,15 +9998,15 @@ exports[`Activity when there is an interaction should render interaction activit
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c7 {
+.c20 > .c7 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
@@ -10021,27 +10021,27 @@ exports[`Activity when there is an interaction should render interaction activit
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -10063,33 +10063,33 @@ exports[`Activity when there is an interaction should render interaction activit
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -10119,7 +10119,7 @@ exports[`Activity when there is an interaction should render interaction activit
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -10131,59 +10131,59 @@ exports[`Activity when there is an interaction should render interaction activit
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }
@@ -10464,7 +10464,7 @@ exports[`Activity when there is an interaction without any people involved shoul
   padding: 15px;
 }
 
-.c11 {
+.c10 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -10583,22 +10583,22 @@ exports[`Activity when there is an interaction without any people involved shoul
   background-color: #ffbf47;
 }
 
-.c10 {
+.c11 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c10 > div {
+.c11 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c10 > div > a {
+.c11 > div > a {
   padding: 20px 0 10px 10px;
 }
 
-.c4 {
+.c3 {
   color: #0b0c0c;
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
@@ -10643,15 +10643,15 @@ exports[`Activity when there is an interaction without any people involved shoul
   width: 100%;
 }
 
-.c3 {
+.c4 {
   font-weight: normal;
   font-size: 24px;
 }
 
-.c3 > a:link,
-.c3 a:visited,
-.c3 a:hover,
-.c3 a:active {
+.c4 > a:link,
+.c4 a:visited,
+.c4 a:hover,
+.c4 a:active {
   -webkit-text-decoration: none;
   text-decoration: none;
   color: #005ea5;
@@ -10691,7 +10691,7 @@ exports[`Activity when there is an interaction without any people involved shoul
   padding-right: 0;
 }
 
-.c16 {
+.c15 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -10705,12 +10705,12 @@ exports[`Activity when there is an interaction without any people involved shoul
   margin-bottom: 20px;
 }
 
-.c15 th {
+.c16 th {
   width: 270px;
 }
 
-.c15 th,
-.c15 td {
+.c16 th,
+.c16 td {
   font-weight: normal;
   border: 0;
   padding: 10px;
@@ -10718,7 +10718,7 @@ exports[`Activity when there is an interaction without any people involved shoul
   vertical-align: top;
 }
 
-.c21 {
+.c20 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -10732,40 +10732,40 @@ exports[`Activity when there is an interaction without any people involved shoul
   padding-left: 0;
 }
 
-.c21 .c20 {
+.c20 .c19 {
   margin-top: 10px;
 }
 
-.c21 > .c7 {
+.c20 > .c7 {
   margin-bottom: 5px;
 }
 
-.c19 {
+.c21 {
   margin-bottom: 0;
 }
 
 @media print {
-  .c11 {
+  .c10 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c11 {
+  .c10 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c11 {
+  .c10 {
     margin-bottom: 30px;
   }
 }
@@ -10787,33 +10787,33 @@ exports[`Activity when there is an interaction without any people involved shoul
 }
 
 @media only screen and (min-width:641px) {
-  .c10 {
+  .c11 {
     margin-top: -15px;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     color: #000;
   }
 }
 
 @media print {
-  .c4 {
+  .c3 {
     font-size: 18px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     font-size: 24px;
     line-height: 1.25;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c3 {
     margin-bottom: 20px;
   }
 }
@@ -10843,7 +10843,7 @@ exports[`Activity when there is an interaction without any people involved shoul
 }
 
 @media only screen and (min-width:641px) {
-  .c3 {
+  .c4 {
     margin-bottom: 30px;
   }
 }
@@ -10855,59 +10855,59 @@ exports[`Activity when there is an interaction without any people involved shoul
 }
 
 @media print {
-  .c16 {
+  .c15 {
     font-size: 14px;
     line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    font-size: 19px;
-    line-height: 1.3157894736842106;
-  }
-}
-
-@media print {
-  .c16 {
-    color: #000;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c16 {
-    margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
   .c15 {
-    margin-bottom: 10px;
-  }
-}
-
-@media print {
-  .c21 {
-    font-size: 14px;
-    line-height: 1.15;
-  }
-}
-
-@media only screen and (min-width:641px) {
-  .c21 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c21 {
+  .c15 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c21 {
+  .c15 {
+    margin-bottom: 30px;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c16 {
+    margin-bottom: 10px;
+  }
+}
+
+@media print {
+  .c20 {
+    font-size: 14px;
+    line-height: 1.15;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
+    font-size: 19px;
+    line-height: 1.3157894736842106;
+  }
+}
+
+@media print {
+  .c20 {
+    color: #000;
+  }
+}
+
+@media only screen and (min-width:641px) {
+  .c20 {
     margin-bottom: 20px;
   }
 }

--- a/src/activity-feed/__tests__/__snapshots__/ActivityFeedHeader.test.jsx.snap
+++ b/src/activity-feed/__tests__/__snapshots__/ActivityFeedHeader.test.jsx.snap
@@ -51,7 +51,7 @@ exports[`ActivityFeedHeader renders header with all props defined 1`] = `
   margin-bottom: 0;
 }
 
-.c4 {
+.c5 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -76,36 +76,36 @@ exports[`ActivityFeedHeader renders header with all props defined 1`] = `
   margin-bottom: 22px;
 }
 
-.c4:focus {
+.c5:focus {
   outline: 3px solid #ffbf47;
   outline-offset: 0;
 }
 
-.c4:link,
-.c4:visited,
-.c4:active,
-.c4:hover {
+.c5:link,
+.c5:visited,
+.c5:active,
+.c5:hover {
   color: #000;
   -webkit-text-decoration: none;
   text-decoration: none;
 }
 
-.c4::-moz-focus-inner {
+.c5::-moz-focus-inner {
   padding: 0;
   border: 0;
 }
 
-.c4:hover,
-.c4:focus {
+.c5:hover,
+.c5:focus {
   background-color: #d0d3d6;
 }
 
-.c4:active {
+.c5:active {
   top: 2px;
   box-shadow: none;
 }
 
-.c4::before {
+.c5::before {
   content: "";
   display: block;
   position: absolute;
@@ -116,34 +116,34 @@ exports[`ActivityFeedHeader renders header with all props defined 1`] = `
   background: transparent;
 }
 
-.c4:active::before {
+.c5:active::before {
   top: -4px;
 }
 
-.c4:disabled {
+.c5:disabled {
   opacity: 0.5;
   background: #dee0e2;
 }
 
-.c4:disabled:hover {
+.c5:disabled:hover {
   background-color: #dee0e2;
   cursor: default;
 }
 
-.c4:disabled:focus {
+.c5:disabled:focus {
   outline: none;
 }
 
-.c4:disabled:active {
+.c5:disabled:active {
   top: 0;
   box-shadow: 0 2px 0 #b5babe;
 }
 
-.c4 svg {
+.c5 svg {
   max-width: 15px;
 }
 
-.c5 {
+.c4 {
   margin-bottom: 0;
   margin-top: 15px;
 }
@@ -185,39 +185,39 @@ exports[`ActivityFeedHeader renders header with all props defined 1`] = `
 }
 
 @media print {
-  .c4 {
+  .c5 {
     font-size: 14px;
     line-height: 19px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c5 {
     font-size: 19px;
     line-height: 19px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c5 {
     width: auto;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 svg {
+  .c5 svg {
     margin-left: 10px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c4 {
+  .c5 {
     margin-bottom: 32px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c5 {
+  .c4 {
     margin-left: 15px;
     margin-top: 0;
   }

--- a/src/activity-feed/__tests__/__snapshots__/ActivityFeedPagination.test.jsx.snap
+++ b/src/activity-feed/__tests__/__snapshots__/ActivityFeedPagination.test.jsx.snap
@@ -404,6 +404,7 @@ exports[`ActivityFeedPagination renders pagination with loader 1`] = `
   >
     <div
       className="c2"
+      loading={true}
     >
       <svg
         className="icon-loading"
@@ -604,7 +605,7 @@ exports[`ActivityFeedPagination renders pagination with loader 1`] = `
         />
       </svg>
       <div
-        className="overlay c4"
+        className="c4 overlay"
       />
     </div>
     <button

--- a/src/activity-feed/activities/card/__tests__/__snapshots__/CardDetails.test.jsx.snap
+++ b/src/activity-feed/activities/card/__tests__/__snapshots__/CardDetails.test.jsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CardDetails when link provided should render the card 1`] = `
-.c1 {
+.c0 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -120,43 +120,43 @@ exports[`CardDetails when link provided should render the card 1`] = `
   background-color: #ffbf47;
 }
 
-.c0 {
+.c1 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c0 > div {
+.c1 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c0 > div > a {
+.c1 > div > a {
   padding: 20px 0 10px 10px;
 }
 
 @media print {
-  .c1 {
+  .c0 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c1 {
+  .c0 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c1 {
+  .c0 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c1 {
+  .c0 {
     margin-bottom: 30px;
   }
 }
@@ -178,7 +178,7 @@ exports[`CardDetails when link provided should render the card 1`] = `
 }
 
 @media only screen and (min-width:641px) {
-  .c0 {
+  .c1 {
     margin-top: -15px;
   }
 }
@@ -214,7 +214,7 @@ exports[`CardDetails when link provided should render the card 1`] = `
 `;
 
 exports[`CardDetails when no link provided should still render the card 1`] = `
-.c1 {
+.c0 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -301,49 +301,49 @@ exports[`CardDetails when no link provided should still render the card 1`] = `
   margin-bottom: 0;
 }
 
-.c0 {
+.c1 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c0 > div {
+.c1 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c0 > div > a {
+.c1 > div > a {
   padding: 20px 0 10px 10px;
 }
 
 @media print {
-  .c1 {
+  .c0 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c1 {
+  .c0 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c1 {
+  .c0 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c1 {
+  .c0 {
     margin-bottom: 30px;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c0 {
+  .c1 {
     margin-top: -15px;
   }
 }
@@ -372,7 +372,7 @@ exports[`CardDetails when no link provided should still render the card 1`] = `
 `;
 
 exports[`CardDetails when the details for all activities are hidden should open the card details 1`] = `
-.c1 {
+.c0 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -491,43 +491,43 @@ exports[`CardDetails when the details for all activities are hidden should open 
   background-color: #ffbf47;
 }
 
-.c0 {
+.c1 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c0 > div {
+.c1 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c0 > div > a {
+.c1 > div > a {
   padding: 20px 0 10px 10px;
 }
 
 @media print {
-  .c1 {
+  .c0 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c1 {
+  .c0 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c1 {
+  .c0 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c1 {
+  .c0 {
     margin-bottom: 30px;
   }
 }
@@ -549,7 +549,7 @@ exports[`CardDetails when the details for all activities are hidden should open 
 }
 
 @media only screen and (min-width:641px) {
-  .c0 {
+  .c1 {
     margin-top: -15px;
   }
 }
@@ -585,7 +585,7 @@ exports[`CardDetails when the details for all activities are hidden should open 
 `;
 
 exports[`CardDetails when the details for all activities are shown should open the card details 1`] = `
-.c1 {
+.c0 {
   font-family: "nta",Arial,sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -704,43 +704,43 @@ exports[`CardDetails when the details for all activities are shown should open t
   background-color: #ffbf47;
 }
 
-.c0 {
+.c1 {
   font-size: 16px;
   margin: 10px 0 0;
 }
 
-.c0 > div {
+.c1 > div {
   padding: 5px;
   padding-bottom: 15px;
   margin: 5px 0 5px 4px;
 }
 
-.c0 > div > a {
+.c1 > div > a {
   padding: 20px 0 10px 10px;
 }
 
 @media print {
-  .c1 {
+  .c0 {
     font-size: 14px;
     line-height: 1.15;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c1 {
+  .c0 {
     font-size: 19px;
     line-height: 1.3157894736842106;
   }
 }
 
 @media print {
-  .c1 {
+  .c0 {
     color: #000;
   }
 }
 
 @media only screen and (min-width:641px) {
-  .c1 {
+  .c0 {
     margin-bottom: 30px;
   }
 }
@@ -762,7 +762,7 @@ exports[`CardDetails when the details for all activities are shown should open t
 }
 
 @media only screen and (min-width:641px) {
-  .c0 {
+  .c1 {
     margin-top: -15px;
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1157,11 +1157,18 @@
   version "0.6.6"
   resolved "https://registry.yarnpkg.com/@emotion/hash/-/hash-0.6.6.tgz#62266c5f0eac6941fece302abad69f2ee7e25e44"
 
-"@emotion/is-prop-valid@0.7.3", "@emotion/is-prop-valid@^0.7.3":
+"@emotion/is-prop-valid@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.7.3.tgz#a6bf4fa5387cbba59d44e698a4680f481a8da6cc"
   dependencies:
     "@emotion/memoize" "0.7.1"
+
+"@emotion/is-prop-valid@^0.8.1":
+  version "0.8.8"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz#db28b1c4368a259b60a97311d6a952d4fd01ac1a"
+  integrity sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
 
 "@emotion/memoize@0.7.1":
   version "0.7.1"
@@ -1254,7 +1261,7 @@
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.7.1.tgz#50f63225e712d99e2b2b39c19c70fff023793ca5"
 
-"@emotion/unitless@0.7.3", "@emotion/unitless@^0.7.0":
+"@emotion/unitless@0.7.3":
   version "0.7.3"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.3.tgz#6310a047f12d21a1036fb031317219892440416f"
 
@@ -1262,7 +1269,7 @@
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.4.tgz#a87b4b04e5ae14a88d48ebef15015f6b7d1f5677"
 
-"@emotion/unitless@0.7.5":
+"@emotion/unitless@0.7.5", "@emotion/unitless@^0.7.0":
   version "0.7.5"
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
 
@@ -3297,13 +3304,14 @@ babel-plugin-react-docgen@^3.0.0:
     recast "^0.14.7"
 
 "babel-plugin-styled-components@>= 1":
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.0.tgz#ff1f42ad2cc78c21f26b62266b8f564dbc862939"
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz#3494e77914e9989b33cc2d7b3b29527a949d635c"
+  integrity sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==
   dependencies:
     "@babel/helper-annotate-as-pure" "^7.0.0"
     "@babel/helper-module-imports" "^7.0.0"
     babel-plugin-syntax-jsx "^6.18.0"
-    lodash "^4.17.10"
+    lodash "^4.17.11"
 
 babel-plugin-syntax-jsx@^6.18.0:
   version "6.18.0"
@@ -3830,6 +3838,7 @@ camelcase@^5.0.0, camelcase@^5.2.0, camelcase@^5.3.1:
 camelize@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/camelize/-/camelize-1.0.0.tgz#164a5483e630fa4321e5af07020e531831b2609b"
+  integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 can-use-dom@^0.1.0:
   version "0.1.0"
@@ -4586,6 +4595,7 @@ crypto-random-string@^1.0.0:
 css-color-keywords@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/css-color-keywords/-/css-color-keywords-1.0.0.tgz#fea2616dc676b2962686b3af8dbdbe180b244e05"
+  integrity sha1-/qJhbcZ2spYmhrOvjb2+GAskTgU=
 
 css-in-js-utils@^2.0.0:
   version "2.0.1"
@@ -4633,8 +4643,9 @@ css-select@^2.0.0:
     nth-check "^1.0.2"
 
 css-to-react-native@^2.2.2:
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.1.tgz#cf0f61e0514846e2d4dc188b0886e29d8bef64a2"
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
+  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
   dependencies:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
@@ -7275,6 +7286,11 @@ is-utf8@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
 
+is-what@^3.3.1:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/is-what/-/is-what-3.8.0.tgz#610bc46a524355f2424eb85eedc6ebbbf7e1ff8c"
+  integrity sha512-UKeBoQfV8bjlM4pmx1FLDHdxslW/1mTksEs8ReVsilPmUv5cORd4+2/wFcviI3cUjrLybxCjzc8DnodAzJ/Wrg==
+
 is-whitespace-character@^1.0.0:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/is-whitespace-character/-/is-whitespace-character-1.0.3.tgz#b3ad9546d916d7d3ffa78204bca0c26b56257fac"
@@ -8569,6 +8585,13 @@ meow@^4.0.0:
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^2.0.0"
+
+merge-anything@^2.2.4:
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/merge-anything/-/merge-anything-2.4.4.tgz#6226b2ac3d3d3fc5fb9e8d23aa400df25f98fdf0"
+  integrity sha512-l5XlriUDJKQT12bH+rVhAHjwIuXWdAIecGwsYjv2LJo+dA1AeRTmeQS+3QBpO6lEthBMDi2IUMpLC1yyRvGlwQ==
+  dependencies:
+    is-what "^3.3.1"
 
 merge-deep@^3.0.2:
   version "3.0.2"
@@ -10527,7 +10550,12 @@ react-inspector@^3.0.2:
     is-dom "^1.0.9"
     prop-types "^15.6.1"
 
-react-is@^16.6.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
+react-is@^16.6.0:
+  version "16.13.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
+  integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.4, react-is@^16.8.6:
   version "16.8.6"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.6.tgz#5bbc1e2d29141c9fbdfed456343fe2bc430a6a16"
 
@@ -12134,15 +12162,18 @@ style-loader@^0.23.1:
     schema-utils "^1.0.0"
 
 styled-components@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.2.0.tgz#811fbbec4d64c7189f6c7482b9eb6fefa7fefef7"
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-4.4.1.tgz#e0631e889f01db67df4de576fedaca463f05c2f2"
+  integrity sha512-RNqj14kYzw++6Sr38n7197xG33ipEOktGElty4I70IKzQF1jzaD1U4xQ+Ny/i03UUhHlC5NWEO+d8olRCDji6g==
   dependencies:
     "@babel/helper-module-imports" "^7.0.0"
-    "@emotion/is-prop-valid" "^0.7.3"
+    "@babel/traverse" "^7.0.0"
+    "@emotion/is-prop-valid" "^0.8.1"
     "@emotion/unitless" "^0.7.0"
     babel-plugin-styled-components ">= 1"
     css-to-react-native "^2.2.2"
     memoize-one "^5.0.0"
+    merge-anything "^2.2.4"
     prop-types "^15.5.4"
     react-is "^16.6.0"
     stylis "^3.5.0"


### PR DESCRIPTION
Having `styled-components` listed in `dependencies` results in having two `styled-components` instances installed in `data-hub-frontend` which also has it as a dependency:

<img width="335" alt="Screen Shot 2020-04-17 at 12 35 41 PM" src="https://user-images.githubusercontent.com/2333157/79569142-02090880-80af-11ea-9820-86953786e586.png">

This then results in this error:
<img width="599" alt="Screen Shot 2020-04-17 at 1 08 34 PM" src="https://user-images.githubusercontent.com/2333157/79569148-033a3580-80af-11ea-8ce9-c9e828d14e5f.png">

This PR moves `styled-components` to [`peerDependencies`](https://docs.npmjs.com/files/package.json#peerdependencies) which should hopefully solve the problem.
