### PR TITLE
feat: Add custom error message to FieldTypeahead

### DIFF
--- a/src/forms/elements/FieldTypeahead.jsx
+++ b/src/forms/elements/FieldTypeahead.jsx
@@ -34,6 +34,7 @@ const FieldTypeahead = ({
   legend,
   hint,
   initialValue,
+  errorMessage,
   ...rest
 }) => {
   const { value, error, touched, onBlur } = useField({
@@ -43,17 +44,20 @@ const FieldTypeahead = ({
     initialValue,
   })
   const { setFieldValue } = useFormContext()
+  const hasError = !!(error || errorMessage)
 
   return (
     <FieldWrapper {...{ name, label, legend, hint, error }}>
-      <StyledWrapper error={error}>
-        {touched && error && <ErrorText>{error}</ErrorText>}
+      <StyledWrapper error={hasError}>
+        {(errorMessage || (touched && error)) && (
+          <ErrorText>{errorMessage || error}</ErrorText>
+        )}
         <Typeahead
           inputId={name}
           aria-label={label || legend}
           onBlur={onBlur}
           onChange={(newValue) => setFieldValue(name, newValue)}
-          error={error}
+          error={hasError}
           value={value}
           {...rest}
         />

--- a/src/forms/elements/__stories__/FieldTypeahead.stories.jsx
+++ b/src/forms/elements/__stories__/FieldTypeahead.stories.jsx
@@ -34,7 +34,7 @@ storiesOf('Forms', module).add('FieldTypeahead', () => (
         <FieldTypeahead
           label="Typeahead - sync single value"
           hint="Some hint"
-          name="sync_single"
+          name="sync_single_1"
           required="Chose value"
           options={options}
         />
@@ -49,7 +49,7 @@ storiesOf('Forms', module).add('FieldTypeahead', () => (
         <FieldTypeahead
           label="Typeahead - initial value"
           hint="Some hint"
-          name="sync_single"
+          name="sync_single_2"
           required="Chose value"
           initialValue={options[1]}
           options={options}
@@ -68,6 +68,14 @@ storiesOf('Forms', module).add('FieldTypeahead', () => (
           required="Chose value"
           loadOptions={getOptions}
           isMulti={true}
+        />
+        <FieldTypeahead
+          label="Typeahead - sync with error message"
+          hint="Some hint"
+          name="sync_single_error"
+          required="Chose value"
+          errorMessage="My custom error message"
+          options={options}
         />
         <Button>Submit</Button>
         <pre>{JSON.stringify(state, null, 2)}</pre>

--- a/src/forms/elements/__tests__/FieldTypeahead.test.jsx
+++ b/src/forms/elements/__tests__/FieldTypeahead.test.jsx
@@ -99,6 +99,27 @@ describe('FieldTypeahead', () => {
     })
   })
 
+  describe('with a custom error message', () => {
+    test('should render error message', () => {
+      const myErrorMesage = 'A custom error occurred'
+      const wrapper = mount(
+        <FormStateful>
+          <FieldTypeahead name="testField" errorMessage={myErrorMesage} />
+        </FormStateful>
+      )
+
+      expect(wrapper.find(ErrorText).text()).toEqual(myErrorMesage)
+
+      const inputWrapper = wrapper
+        .find(FieldWrapper)
+        .find('div')
+        .at(1)
+      expect(inputWrapper).toHaveStyleRule('border-left', '4px solid #b10e1e')
+      expect(inputWrapper).toHaveStyleRule('margin-right', '15px')
+      expect(inputWrapper).toHaveStyleRule('padding-left', '10px')
+    })
+  })
+
   describe('when the text is typed to the typeahead', () => {
     test('should update field value', async () => {
       const Value = () => {


### PR DESCRIPTION
To enable showing a dynamic validation error we need more than just the `validate` prop, to give ultimate control the the parent add a simple `errorMessage` prop which will put the wrapper and typeahead in an error state and render the error message -  this should play nicely with the existing validation