### PR TITLE
fix: Reduce top margin for details in CollectionItem

### DIFF
--- a/src/collection-list/CollectionItem.jsx
+++ b/src/collection-list/CollectionItem.jsx
@@ -48,7 +48,7 @@ const StyledSubheading = styled('h4')`
 `
 
 const StyledDetails = styled(Details)`
-  margin: 50px 0 0 0;
+  margin: ${SPACING.SCALE_3} 0 0 0;
 `
 
 function CollectionItem({


### PR DESCRIPTION
There was a massive margin above the details so this reduces it

## Screenshots

### Before
<img width="944" alt="Screenshot 2020-04-29 at 08 30 36" src="https://user-images.githubusercontent.com/1481883/80572911-fabef480-89f6-11ea-87d8-a3916e46247f.png">

### After
<img width="945" alt="Screenshot 2020-04-29 at 08 29 58" src="https://user-images.githubusercontent.com/1481883/80572938-01e60280-89f7-11ea-9ef0-ea2e5dc73f8d.png">
