### PR TITLE
fix: Allow setFieldValue to accept empty strings

### DIFF
--- a/src/forms/hooks/__tests__/useForm.test.jsx
+++ b/src/forms/hooks/__tests__/useForm.test.jsx
@@ -278,12 +278,12 @@ describe('useForm', () => {
       })
     })
 
-    test('should unset the field value', () => {
-      expect(formState.values).toEqual({})
+    test('should set the field value', () => {
+      expect(formState.values).toEqual({ testField: '' })
     })
 
-    test('should set "isDirty" to false', () => {
-      expect(formState.isDirty).toBeFalsy()
+    test('should set "isDirty" to true', () => {
+      expect(formState.isDirty).toBeTruthy()
     })
   })
 

--- a/src/forms/hooks/useForm.js
+++ b/src/forms/hooks/useForm.js
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { isEmpty, isEqual, omit } from 'lodash'
+import { isEmpty, isEqual } from 'lodash'
 import { useDeepCompareEffect } from 'react-use'
 
 // Based on react-use/useBeforeUnload but can handle custom handlers (for tests).
@@ -129,10 +129,6 @@ function useForm({
 
   const setFieldValue = (name, fieldValue) =>
     setValues((prevValues) => {
-      if (fieldValue === '') {
-        return omit(prevValues, name)
-      }
-
       return { ...prevValues, [name]: fieldValue }
     })
   const setFieldTouched = (name, fieldTouched) => {


### PR DESCRIPTION
This PR relates to another PR in the DH front end: https://github.com/uktrade/data-hub-frontend/pull/2672

This PR fixes a bug with the useForm hook, which initially omitted a form field that had been passed an empty string. This would cause the unwanted behaviour of not updating an optional field to an empty string, if a value had been previously submitted or stored on the API. 

The fix is to simply remove the code that would check if the string was empty and omit it. 

Tests have been amended to reflect that we now want to accept an empty string as a value. 