### PR TITLE
fix: Search DnB companies - only set the postcode if it's defined

### DIFF
--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react'
 import PropTypes from 'prop-types'
-import { isEmpty } from 'lodash'
+import { isEmpty, omitBy } from 'lodash'
 import styled from 'styled-components'
 
 import { WIDTHS, SPACING } from '@govuk-react/constants'
@@ -66,11 +66,16 @@ const FieldDnbCompany = ({
     e.preventDefault()
     const noValidationErrors = isEmpty(validateForm())
     if (noValidationErrors) {
-      return onEntitySearch({
-        ...queryParams,
-        search_term: values.dnbCompanyName,
-        postal_code: values.dnbPostalCode,
-      })
+      return onEntitySearch(
+        omitBy(
+          {
+            ...queryParams,
+            search_term: values.dnbCompanyName,
+            postal_code: values.dnbPostalCode,
+          },
+          isEmpty
+        )
+      )
     }
     return null
   }


### PR DESCRIPTION
Steps to reproduce (Add company):
1. Go to dev `/companies/create`
2. Select UK and continue
3. Add a company name such as Lambda and search (yields results)
4. Add any postcode and search again (yields zero results)
5. Clear the postcode field and search again (error HTTP 400)

The problem lies in the existence of an empty postcode field in the body of the POST. The D&B API takes both the company name and the postcode and applies AND Boolean Logic when querying their database. The API errors whenever the postcode is an empty string.

To fix the issue we need to ensure the `postal_code` field is not included in the body of the POST when it's an empty string.