### PR TITLE
Normalise date format

### DIFF
--- a/src/forms/elements/FieldDate.jsx
+++ b/src/forms/elements/FieldDate.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import moment from 'moment'
 import { castArray } from 'lodash'
 import styled from 'styled-components'
 import { ERROR_COLOUR } from 'govuk-colours'
@@ -16,9 +15,8 @@ import {
 import FieldWrapper from './FieldWrapper'
 import useField from '../hooks/useField'
 import useFormContext from '../hooks/useFormContext'
+import DateUtils from '../../utils/DateUtils'
 
-const DATE_FORMAT_LONG = 'YYYY-MM-DD'
-const DATE_FORMAT_SHORT = 'YYYY-MM'
 const DAY = 'day'
 const MONTH = 'month'
 const YEAR = 'year'
@@ -48,16 +46,11 @@ const StyledList = styled('div')({
   display: 'flex',
 })
 
-const isDateStrValid = (dateStr, format) => {
-  return moment(dateStr, format, true).isValid()
-}
-
 const getValidator = (required, format) => ({ day, month, year }) => {
   const isLong = format === FORMAT_LONG
-
   const isDateValid = isLong
-    ? isDateStrValid(`${year}-${month}-${day}`, DATE_FORMAT_LONG)
-    : isDateStrValid(`${year}-${month}`, DATE_FORMAT_SHORT)
+    ? DateUtils.isDateValid(year, month, day)
+    : DateUtils.isShortDateValid(year, month)
 
   const isDateEmpty = isLong ? !day && !month && !year : !month && !year
 

--- a/src/forms/elements/__tests__/FieldDate.test.jsx
+++ b/src/forms/elements/__tests__/FieldDate.test.jsx
@@ -482,3 +482,79 @@ describe('FieldDate', () => {
     })
   })
 })
+
+describe('normalising FieldDate value', () => {
+  let fieldDate
+
+  function setUpComponent(wrapper, long = true) {
+    const dayInput = long && wrapper.find('input[type="number"]').at(0)
+    const monthInput = wrapper.find('input[type="number"]').at(long ? 1 : 0)
+    const yearInput = wrapper.find('input[type="number"]').at(long ? 2 : 1)
+    return {
+      day(value) {
+        dayInput.simulate('change', { target: { value } })
+      },
+      month(value) {
+        monthInput.simulate('change', { target: { value } })
+      },
+      year(value) {
+        yearInput.simulate('change', { target: { value } })
+      },
+      submit() {
+        wrapper.find('form').simulate('submit')
+      },
+      wrapper,
+    }
+  }
+  describe('normalising long date formats', () => {
+    beforeAll(() => {
+      const wrapper = mount(
+        <FormStateful>
+          <FieldDate name="date" />
+        </FormStateful>
+      )
+      fieldDate = setUpComponent(wrapper)
+    })
+
+    test('without leading 0 should not render an error message', () => {
+      fieldDate.day('9')
+      fieldDate.month('9')
+      fieldDate.year('2019')
+      fieldDate.submit()
+      expect(fieldDate.wrapper.find(ErrorText).exists()).toEqual(false)
+    })
+
+    test('with leading 0 should not render an error message', () => {
+      fieldDate.day('09')
+      fieldDate.month('09')
+      fieldDate.year('2019')
+      fieldDate.submit()
+      expect(fieldDate.wrapper.find(ErrorText).exists()).toEqual(false)
+    })
+  })
+
+  describe('normalising short date formats', () => {
+    beforeAll(() => {
+      const wrapper = mount(
+        <FormStateful>
+          <FieldDate name="date" format="short" />
+        </FormStateful>
+      )
+      fieldDate = setUpComponent(wrapper, false)
+    })
+
+    test('without leading 0 should not render an error message', () => {
+      fieldDate.month('9')
+      fieldDate.year('2019')
+      fieldDate.submit()
+      expect(fieldDate.wrapper.find(ErrorText).exists()).toEqual(false)
+    })
+
+    test('with leading 0 should not render an error message', () => {
+      fieldDate.month('09')
+      fieldDate.year('2019')
+      fieldDate.submit()
+      expect(fieldDate.wrapper.find(ErrorText).exists()).toEqual(false)
+    })
+  })
+})

--- a/src/utils/DateUtils.js
+++ b/src/utils/DateUtils.js
@@ -1,5 +1,23 @@
 import moment from 'moment'
 
+const DATE_FORMAT_LONG = 'YYYY-MM-DD'
+const DATE_FORMAT_SHORT = 'YYYY-MM'
+
+function padZero(value) {
+  const parsedValue = parseInt(value, 10)
+  if (Number.isNaN(parsedValue)) {
+    return value
+  }
+  return parsedValue < 10 ? `0${parsedValue}` : parsedValue.toString()
+}
+
+function normaliseAndFormatDate(year, month, day) {
+  const y = padZero(year)
+  const m = padZero(month)
+  const yearAndMonth = `${padZero(y)}-${padZero(m)}`
+  return day ? `${yearAndMonth}-${padZero(day)}` : yearAndMonth
+}
+
 export default class DateUtils {
   static format(dateStr) {
     return moment(dateStr).format('DD MMM YYYY')
@@ -7,5 +25,22 @@ export default class DateUtils {
 
   static formatWithTime(dateTimeStr) {
     return moment(dateTimeStr).format('D MMM YYYY, h:mma')
+  }
+
+  static isDateValid = (year, month, day, format = DATE_FORMAT_LONG) => {
+    const date = normaliseAndFormatDate(year, month, day)
+    return moment(date, format, true).isValid()
+  }
+
+  static isShortDateValid(year, month) {
+    return DateUtils.isDateValid(year, month, null, DATE_FORMAT_SHORT)
+  }
+
+  static transformValueForAPI({ year, month, day = 1 }) {
+    if (year && month && day) {
+      return normaliseAndFormatDate(year, month, day)
+    }
+
+    return null
   }
 }

--- a/src/utils/__tests__/DateUtils.test.js
+++ b/src/utils/__tests__/DateUtils.test.js
@@ -25,4 +25,84 @@ describe('DateUtils.js', () => {
       expect(formattedDateAndTime).toEqual('10 Dec 2019, 6:12pm')
     })
   })
+
+  describe('the isDateValid() function', () => {
+    test('should return true if valid', () => {
+      expect(DateUtils.isDateValid('2020', '1', '1')).toEqual(true)
+      expect(DateUtils.isDateValid('2020', '01', '01')).toEqual(true)
+      expect(DateUtils.isDateValid(2020, 1, 1)).toEqual(true)
+    })
+
+    test('should return false if invalid', () => {
+      expect(DateUtils.isDateValid('2020', '0', '1')).toEqual(false)
+      expect(DateUtils.isDateValid('2020', '0', '01')).toEqual(false)
+      expect(DateUtils.isDateValid(2020, 0, 1)).toEqual(false)
+    })
+  })
+
+  describe('the isShortDateValid() function', () => {
+    test('should return true if valid', () => {
+      expect(DateUtils.isShortDateValid('2020', '1')).toEqual(true)
+      expect(DateUtils.isShortDateValid('2020', '01')).toEqual(true)
+      expect(DateUtils.isShortDateValid(2020, 1)).toEqual(true)
+    })
+
+    test('should return false if invalid', () => {
+      expect(DateUtils.isShortDateValid('2020', '0')).toEqual(false)
+      expect(DateUtils.isShortDateValid('2020', '13')).toEqual(false)
+      expect(DateUtils.isShortDateValid(2020, 0)).toEqual(false)
+    })
+  })
+
+  describe('transform value to DD-MM-YYYY', () => {
+    test('empty or incomplete date should return null', () => {
+      expect(DateUtils.transformValueForAPI({})).toEqual(null)
+      expect(
+        DateUtils.transformValueForAPI({ day: '', month: '', year: '' })
+      ).toEqual(null)
+      expect(
+        DateUtils.transformValueForAPI({ day: '', month: '04', year: '2020' })
+      ).toEqual(null)
+    })
+    describe('transforming long date formats', () => {
+      test('with leading 0 should render YYYY-MM-DD', () => {
+        expect(
+          DateUtils.transformValueForAPI({
+            year: '2020',
+            month: '09',
+            day: '09',
+          })
+        ).toEqual('2020-09-09')
+      })
+
+      test('without leading 0 should render YYYY-MM-DD', () => {
+        expect(
+          DateUtils.transformValueForAPI({
+            year: '2020',
+            month: '9',
+            day: '9',
+          })
+        ).toEqual('2020-09-09')
+      })
+    })
+
+    describe('transforming short date formats', () => {
+      test('with leading 0 should render YYYY-MM-DD', () => {
+        expect(
+          DateUtils.transformValueForAPI({
+            year: '2020',
+            month: '09',
+          })
+        ).toEqual('2020-09-01')
+      })
+      test('without leading 0 should render YYYY-MM-DD', () => {
+        expect(
+          DateUtils.transformValueForAPI({
+            year: '2020',
+            month: '9',
+          })
+        ).toEqual('2020-09-01')
+      })
+    })
+  })
 })


### PR DESCRIPTION
At the moment (no pun intended) the DateFiled only accepts YYYY-MM-DD if a user types in
1-6-2020 for June 1st 2020 it will throw a validation error because it is expects the leading 0.

This PR will normalise date to include the '0' if `n > 10` 
I am aware the moment supports multiple formats however multiple format looks messy 

```js 
moment(dateStr, ['YYYY-MM-DD', 'YYYY-MM-D', 'YYYY-M-D', 'YYYY-M-DD'])
moment(dateStr, ['YYYY-MM', 'YYYY-M'])
``` 
and there is a note on their website 

[Note: Parsing multiple formats is considerably slower than parsing a single format. If you can avoid it, it is much faster to parse a single format.](https://momentjs.com/docs/#/parsing/string-formats/#:~:text=Note:%20Parsing%20multiple%20formats%20is%20considerably%20slower%20than%20parsing%20a%20single%20format.%20If%20you%20can%20avoid%20it,%20it%20is%20much%20faster%20to%20parse%20a%20single%20format.)
![image](https://user-images.githubusercontent.com/5575331/84520008-cd8a8500-acca-11ea-8cd7-9656ccab6369.png)

### Next 
There will be a PR on data-hub-fronend to use the 
`transformValueToString`

src/apps/interactions/apps/details-form/client/tasks.js
src/apps/my-pipeline/client/tasks.js