### PR TITLE
feat: Round a number to n significant digits

### DIFF
--- a/src/utils/NumberUtils.js
+++ b/src/utils/NumberUtils.js
@@ -38,4 +38,12 @@ export default class NumberUtils {
 
     return formatter.format(number)
   }
+
+  static roundToSignificantDigits(number, sigDig) {
+    if (!number && number !== 0) {
+      return null
+    }
+
+    return Number(number.toPrecision(sigDig))
+  }
 }

--- a/src/utils/__tests__/NumberUtils.test.js
+++ b/src/utils/__tests__/NumberUtils.test.js
@@ -60,4 +60,16 @@ describe('NumberUtils.js', () => {
       expect('$1,200,000').toEqual(expected)
     })
   })
+
+  describe('the roundToSignificantDigits() function', () => {
+    test('should return null when the value is null', () => {
+      expect(NumberUtils.roundToSignificantDigits(null, 2)).toEqual(null)
+    })
+
+    test('should round to 2 significant digits (not scientific notation)', () => {
+      expect(NumberUtils.roundToSignificantDigits(104, 2)).toEqual(100)
+      expect(NumberUtils.roundToSignificantDigits(105, 2)).toEqual(110)
+      expect(NumberUtils.roundToSignificantDigits(106, 2)).toEqual(110)
+    })
+  })
 })


### PR DESCRIPTION
A utility function that allows us to round a `Number` to `n` significant digits. This is helpful when working with larger numbers such as company turnover. For example, a company's turnover is provided in USD from D&B, after the conversion to GBP we can end up with large values such as `2477018007.2000003`. Once this has been rounded to 2 significant figures we end up with `2500000000` allowing the user to edit the value if the D&B estimated turnover is incorrect.