### PR TITLE
fix: select option fix

### DIFF
--- a/src/forms/elements/FieldSelect.jsx
+++ b/src/forms/elements/FieldSelect.jsx
@@ -32,8 +32,7 @@ const FieldSelect = ({
         meta={{ error, touched }}
         input={{
           id: name,
-          value,
-          readOnly: true,
+          defaultValue: value,
           ...rest,
         }}
       >

--- a/src/forms/elements/__tests__/FieldSelect.test.jsx
+++ b/src/forms/elements/__tests__/FieldSelect.test.jsx
@@ -175,12 +175,19 @@ describe('FieldSelect', () => {
         .simulate('change', { target: { value: 'testOptionValue2' } })
     })
 
-    test('should update the field value', () => {
-      expect(wrapper.find('select').prop('value')).toEqual('testOptionValue2')
+    test('should update the defaultValue', () => {
+      expect(wrapper.find('select').prop('defaultValue')).toEqual(
+        'testOptionValue2'
+      )
     })
 
-    test('should set the readonly flag', () => {
-      expect(wrapper.find('select').prop('readOnly')).toEqual(true)
+    test('should have a selected attribute', () => {
+      expect(
+        wrapper
+          .find('select option')
+          .first()
+          .html()
+      ).toContain('selected')
     })
 
     test('should update value in form state', () => {

--- a/src/utils/NumberUtils.js
+++ b/src/utils/NumberUtils.js
@@ -38,4 +38,12 @@ export default class NumberUtils {
 
     return formatter.format(number)
   }
+
+  static roundToSignificantDigits(number, sigDig) {
+    if (!number && number !== 0) {
+      return null
+    }
+
+    return Number(number.toPrecision(sigDig))
+  }
 }

--- a/src/utils/__tests__/NumberUtils.test.js
+++ b/src/utils/__tests__/NumberUtils.test.js
@@ -60,4 +60,16 @@ describe('NumberUtils.js', () => {
       expect('$1,200,000').toEqual(expected)
     })
   })
+
+  describe('the roundToSignificantDigits() function', () => {
+    test('should return null when the value is null', () => {
+      expect(NumberUtils.roundToSignificantDigits(null, 2)).toEqual(null)
+    })
+
+    test('should round to 2 significant digits (not scientific notation)', () => {
+      expect(NumberUtils.roundToSignificantDigits(104, 2)).toEqual(100)
+      expect(NumberUtils.roundToSignificantDigits(105, 2)).toEqual(110)
+      expect(NumberUtils.roundToSignificantDigits(106, 2)).toEqual(110)
+    })
+  })
 })


### PR DESCRIPTION
It appears when using React's [recommended](https://reactjs.org/docs/forms.html#the-select-tag) approach to select an option combined with a [govuk-react](https://github.com/govuk-react/govuk-react) [select](https://github.com/govuk-react/govuk-react/tree/master/components/select) we don't get a `selected` attribute on the currently selected option which is causing some FE tests to fail.
