### PR TITLE
Update content around DNB company search when no matches are found

### DIFF
--- a/src/forms/elements/FieldDnbCompany.jsx
+++ b/src/forms/elements/FieldDnbCompany.jsx
@@ -132,7 +132,9 @@ const FieldDnbCompany = ({
           )}
 
           {!error && entities.length === 0 && (
-            <StatusMessage>There are no companies to show.</StatusMessage>
+            <StatusMessage>
+              No match found. Try one of the options below.
+            </StatusMessage>
           )}
 
           {error && (
@@ -145,16 +147,16 @@ const FieldDnbCompany = ({
             <Paragraph>Try:</Paragraph>
 
             <StyledUnorderedList>
+              <ListItem>checking or removing the postcode</ListItem>
+              <ListItem>
+                removing &quot;limited&quot; or &quot;ltd&quot;
+              </ListItem>
               <ListItem>checking for spelling errors</ListItem>
               {country && (
                 <ListItem>checking if the right country was selected</ListItem>
               )}
               <ListItem>
                 check you&apos;re using the company&apos;s registered name
-              </ListItem>
-              <ListItem>checking or removing the postcode</ListItem>
-              <ListItem>
-                removing &quot;limited&quot; or &quot;ltd&quot;
               </ListItem>
             </StyledUnorderedList>
 

--- a/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
+++ b/src/forms/elements/__tests__/FieldDnbCompany.test.jsx
@@ -280,7 +280,7 @@ describe('FieldDnbCompany', () => {
 
     test('should show a warning', () => {
       expect(wrapper.find(StatusMessage).text()).toEqual(
-        'There are no companies to show.'
+        'No match found. Try one of the options below.'
       )
     })
 
@@ -341,10 +341,10 @@ describe('FieldDnbCompany', () => {
       await performSearch(fieldWrapper)
 
       expect(fieldWrapper.find('ul').text()).toEqual(
-        'checking for spelling errors' +
-          "check you're using the company's registered name" +
-          'checking or removing the postcode' +
-          'removing "limited" or "ltd"'
+        'checking or removing the postcode' +
+          'removing "limited" or "ltd"' +
+          'checking for spelling errors' +
+          "check you're using the company's registered name"
       )
     })
   })
@@ -361,11 +361,11 @@ describe('FieldDnbCompany', () => {
       await performSearch(fieldWrapper)
 
       expect(fieldWrapper.find('ul').text()).toEqual(
-        'checking for spelling errors' +
+        'checking or removing the postcode' +
+          'removing "limited" or "ltd"' +
+          'checking for spelling errors' +
           'checking if the right country was selected' +
-          "check you're using the company's registered name" +
-          'checking or removing the postcode' +
-          'removing "limited" or "ltd"'
+          "check you're using the company's registered name"
       )
     })
   })


### PR DESCRIPTION
## Description
Whilst searching for a DNB company some content changes are needed to be done which will make it clearer to the user when no match is found. See Trello - https://trello.com/c/cBs92dLr/26-move-check-postcode-to-top-of-list-signal-at-the-tips-below-from-the-blue-box 

## Screenshot
![Screenshot 2020-07-09 at 12 26 55](https://user-images.githubusercontent.com/10154302/87034283-83b89000-c1df-11ea-9cca-3b3fe1e2b40f.png)
