### PR TITLE
refactor: Add accessibility labels to the ActivityFeed filters

### DIFF
--- a/src/activity-feed/ActivityFeedCheckbox.jsx
+++ b/src/activity-feed/ActivityFeedCheckbox.jsx
@@ -42,7 +42,11 @@ const StyledCheckbox = styled(Checkbox)`
 
 const ActivityFeedCheckbox = (props) => {
   const { children, ...rest } = props
-  return <StyledCheckbox {...rest}>{children}</StyledCheckbox>
+  return (
+    <StyledCheckbox aria-label="activity-across-all-companies" {...rest}>
+      {children}
+    </StyledCheckbox>
+  )
 }
 
 ActivityFeedCheckbox.propTypes = {

--- a/src/activity-feed/filters/SelectFilter.jsx
+++ b/src/activity-feed/filters/SelectFilter.jsx
@@ -47,8 +47,9 @@ const SelectFilter = ({ filters, onActivityTypeFilterChange, value }) => {
   return (
     <StyledDropdownContainer>
       <Select
-        input={{ defaultValue: value }}
+        input={{ defaultValue: value, id: 'activity-types' }}
         name="activity-types-filter"
+        htmlFor="activity-types"
         label="Activity types"
         onChange={onActivityTypeFilterChange}
       >

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -2,14 +2,24 @@
 export { default as ActivityFeed } from './activity-feed/ActivityFeed'
 export { default as ActivityFeedApp } from './activity-feed/ActivityFeedApp'
 export { default as Activity } from './activity-feed/Activity'
-export { default as ActivityFeedFilters } from './activity-feed/ActivityFeedFilters'
-export { default as ActivityFeedHeader } from './activity-feed/ActivityFeedHeader'
-export { default as ActivityFeedPagination } from './activity-feed/ActivityFeedPagination'
-export { default as ActivityFeedAction } from './activity-feed/ActivityFeedAction'
+export {
+  default as ActivityFeedFilters,
+} from './activity-feed/ActivityFeedFilters'
+export {
+  default as ActivityFeedHeader,
+} from './activity-feed/ActivityFeedHeader'
+export {
+  default as ActivityFeedPagination,
+} from './activity-feed/ActivityFeedPagination'
+export {
+  default as ActivityFeedAction,
+} from './activity-feed/ActivityFeedAction'
 
 // Address search
 export { default as useAddressSearch } from './address-search/useAddressSearch'
-export { default as usePostcodeLookup } from './address-search/usePostcodeLookup'
+export {
+  default as usePostcodeLookup,
+} from './address-search/usePostcodeLookup'
 
 // Badge
 export { default as Badge } from './badge/Badge'
@@ -22,13 +32,21 @@ export { default as CollectionList } from './collection-list/CollectionList'
 export { default as CollectionItem } from './collection-list/CollectionItem'
 
 // Company lists
-export { default as DeleteCompanyListSection } from './company-lists/DeleteCompanyListSection'
+export {
+  default as DeleteCompanyListSection,
+} from './company-lists/DeleteCompanyListSection'
 export { default as CreateListForm } from './company-lists/CreateListForm'
-export { default as AddRemoveFromListForm } from './company-lists/AddRemoveFromListForm'
+export {
+  default as AddRemoveFromListForm,
+} from './company-lists/AddRemoveFromListForm'
 
 // Dashboard
-export { default as MyCompaniesTile } from './dashboard/my-companies/MyCompaniesTile'
-export { default as useMyCompaniesContext } from './dashboard/my-companies/useMyCompaniesContext'
+export {
+  default as MyCompaniesTile,
+} from './dashboard/my-companies/MyCompaniesTile'
+export {
+  default as useMyCompaniesContext,
+} from './dashboard/my-companies/useMyCompaniesContext'
 
 // Entity search
 export { default as useDnbSearch } from './entity-search/useDnbSearch'


### PR DESCRIPTION
As part of Accessibility, we've needed to add `for` and `id` attributes or `aria-label` attributes for form controls. The following components have been affected: 

ActivityFeedCheckbox - added an `aria-label` as it seems the react checkboxes don't take `htmlFor`.
SelectFilter - added `for` and `id` attributes. 