### PR TITLE
Accessibility work: Add accessibility attributes to the ActivityFeed's filters

### DIFF
--- a/src/activity-feed/ActivityFeedCheckbox.jsx
+++ b/src/activity-feed/ActivityFeedCheckbox.jsx
@@ -42,7 +42,11 @@ const StyledCheckbox = styled(Checkbox)`
 
 const ActivityFeedCheckbox = (props) => {
   const { children, ...rest } = props
-  return <StyledCheckbox {...rest}>{children}</StyledCheckbox>
+  return (
+    <StyledCheckbox aria-label="activity-across-all-companies" {...rest}>
+      {children}
+    </StyledCheckbox>
+  )
 }
 
 ActivityFeedCheckbox.propTypes = {

--- a/src/activity-feed/filters/SelectFilter.jsx
+++ b/src/activity-feed/filters/SelectFilter.jsx
@@ -47,9 +47,10 @@ const SelectFilter = ({ filters, onActivityTypeFilterChange, value }) => {
   return (
     <StyledDropdownContainer>
       <Select
-        input={{ defaultValue: value }}
+        input={{ defaultValue: value, id: 'activity-types' }}
         name="activity-types-filter"
         label="Activity types"
+        htmlFor="activity-types"
         onChange={onActivityTypeFilterChange}
       >
         {map(filters, (item, index) => {


### PR DESCRIPTION
As part of the accessibility work currently going on, a sample of 25 pages are having accessibility fixes made to them before audit. One of the pages in the sample uses the ActivityFeed filters which are still hosted in this project. 

This PR adds some `for` and `id` attributes, and `aria-label` attributes to the ActivityFeed filters, in order to make them accessible. 